### PR TITLE
Translate "CDN Links" page

### DIFF
--- a/content/docs/cdn-links.md
+++ b/content/docs/cdn-links.md
@@ -34,4 +34,4 @@ Nous vous conseillons également de vérifier que le CDN que vous utilisez défi
 
 ![Access-Control-Allow-Origin: *](../images/docs/cdn-cors-header.png)
 
-Cela offre une meilleure [expérience de la gestion des erreurs](/blog/2017/07/26/error-handling-in-react-16.html) avec React 16 et des versions ultérieures.
+Cela améliore l’[expérience de gestion des erreurs](/blog/2017/07/26/error-handling-in-react-16.html) avec React 16 et des versions ultérieures.

--- a/content/docs/cdn-links.md
+++ b/content/docs/cdn-links.md
@@ -1,6 +1,6 @@
 ---
 id: cdn-links
-title: Liens du CDN
+title: Liens CDN
 permalink: docs/cdn-links.html
 prev: create-a-new-react-app.html
 next: hello-world.html

--- a/content/docs/cdn-links.md
+++ b/content/docs/cdn-links.md
@@ -1,37 +1,37 @@
 ---
 id: cdn-links
-title: CDN Links
+title: Liens du CDN
 permalink: docs/cdn-links.html
 prev: create-a-new-react-app.html
 next: hello-world.html
 ---
 
-Both React and ReactDOM are available over a CDN.
+React et ReactDOM sont tous deux accessibles depuis un CDN.
 
 ```html
 <script crossorigin src="https://unpkg.com/react@16/umd/react.development.js"></script>
 <script crossorigin src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"></script>
 ```
 
-The versions above are only meant for development, and are not suitable for production. Minified and optimized production versions of React are available at:
+Les versions ci-dessus ne doivent être utilisées qu'à des fins de développement et ne sont pas adaptées à l'utilisation en production. Les versions minifiées et optimisées pour la production sont disponibles ici :
 
 ```html
 <script crossorigin src="https://unpkg.com/react@16/umd/react.production.min.js"></script>
 <script crossorigin src="https://unpkg.com/react-dom@16/umd/react-dom.production.min.js"></script>
 ```
 
-To load a specific version of `react` and `react-dom`, replace `16` with the version number.
+Pour charger une version spécifique de `react` et `react-dom`, il suffit de remplacer le `16` par la version désirée.
 
-### Why the `crossorigin` Attribute? {#why-the-crossorigin-attribute}
+### Pourquoi l'attribut `crossorigin` est-il présent ? {#why-the-crossorigin-attribute}
 
-If you serve React from a CDN, we recommend to keep the [`crossorigin`](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes) attribute set:
+Si vous chargez React depuis un CDN, nous vous recommandons de conserver l'attribut [`crossorigin`](https://developer.mozilla.org/fr/docs/Web/HTML/Reglages_des_attributs_CORS) :
 
 ```html
 <script crossorigin src="..."></script>
 ```
 
-We also recommend to verify that the CDN you are using sets the `Access-Control-Allow-Origin: *` HTTP header:
+Nous recommandons de vérifier que le CDN que vous utilisez définit l'entête HTTP `Access-Control-Allow-Origin: *` :
 
 ![Access-Control-Allow-Origin: *](../images/docs/cdn-cors-header.png)
 
-This enables a better [error handling experience](/blog/2017/07/26/error-handling-in-react-16.html) in React 16 and later.
+Cela offre une meilleure [expérience de la gestion des erreurs](/blog/2017/07/26/error-handling-in-react-16.html) avec React 16 et des versions ultérieures.

--- a/content/docs/cdn-links.md
+++ b/content/docs/cdn-links.md
@@ -20,7 +20,7 @@ Les versions ci-dessus ne doivent être utilisées qu'à des fins de développem
 <script crossorigin src="https://unpkg.com/react-dom@16/umd/react-dom.production.min.js"></script>
 ```
 
-Pour charger une version spécifique de `react` et `react-dom`, il suffit de remplacer le `16` par la version désirée.
+Pour charger une version spécifique de `react` et `react-dom`, il suffit de remplacer le `16` par la version souhaitée.
 
 ### Pourquoi l'attribut `crossorigin` est-il présent ? {#why-the-crossorigin-attribute}
 

--- a/content/docs/cdn-links.md
+++ b/content/docs/cdn-links.md
@@ -30,7 +30,7 @@ Si vous chargez React depuis un CDN, nous vous recommandons de conserver l'attri
 <script crossorigin src="..."></script>
 ```
 
-Nous recommandons de vérifier que le CDN que vous utilisez définit l'entête HTTP `Access-Control-Allow-Origin: *` :
+Nous vous conseillons également de vérifier que le CDN que vous utilisez définit bien l'en-tête HTTP `Access-Control-Allow-Origin: *` :
 
 ![Access-Control-Allow-Origin: *](../images/docs/cdn-cors-header.png)
 

--- a/content/docs/cdn-links.md
+++ b/content/docs/cdn-links.md
@@ -22,7 +22,7 @@ Les versions ci-dessus ne doivent être utilisées qu'à des fins de développem
 
 Pour charger une version spécifique de `react` et `react-dom`, il suffit de remplacer le `16` par la version souhaitée.
 
-### Pourquoi l'attribut `crossorigin` est-il présent ? {#why-the-crossorigin-attribute}
+### Pourquoi utiliser l'attribut `crossorigin` ? {#why-the-crossorigin-attribute}
 
 Si vous chargez React depuis un CDN, nous vous recommandons de conserver l'attribut [`crossorigin`](https://developer.mozilla.org/fr/docs/Web/HTML/Reglages_des_attributs_CORS) :
 


### PR DESCRIPTION
Bonjour,

Voici ma proposition de traduction de la page [CDN Links](https://reactjs.org/docs/cdn-links.html).

J'ai toutefois une hésitation sur le titre. J'ai mis `Liens du CDN`, mais est-ce la meilleure option ?