### PR TITLE
Translate "Create a New React App" page

### DIFF
--- a/content/docs/create-a-new-react-app.md
+++ b/content/docs/create-a-new-react-app.md
@@ -81,7 +81,7 @@ Les chaînes d'outils suivantes offrent plus de flexibilité et de choix. Nous l
 
 ## Créer une chaîne d'outils à partir de rien {#creating-a-toolchain-from-scratch}
 
-Une chaîne d'outils de construction en JavaScript consiste généralement en :
+Une chaîne d'outils de construction en JavaScript comprend généralement :
 
 * Un **gestionnaire de paquets**, tel que [Yarn](https://yarnpkg.com/) ou [npm](https://www.npmjs.com/). Il vous permet de tirer parti d'un vaste écosystème de paquets tiers, et de les installer ou les mettre à jour facilement.
 

--- a/content/docs/create-a-new-react-app.md
+++ b/content/docs/create-a-new-react-app.md
@@ -24,7 +24,7 @@ Les chaînes d'outils recommandées sur cette page **ne nécessitent aucune conf
 
 Si vous ne rencontrez pas les problèmes décrits ci-dessus ou si vous n'êtes pas encore à l'aise avec l'utilisation d'outils JavaScript, envisagez [d'ajouter React comme une simple balise `<script>` sur une page HTML](/docs/add-react-to-a-website.html), éventuellement [avec du JSX](/docs/add-react-to-a-website.html#optional-try-react-with-jsx).
 
-C'est également **la façon la plus simple d'intégrer React au sein d'un site web existant**. Vous pourrez toujours étendre votre chaîne d'outils si vous trouvez cela utile !
+C'est également **la façon la plus simple d'intégrer React au sein d'un site web existant**. Vous pourrez toujours étendre votre outillage si ça vous semble utile !
 
 ## Chaînes d'outils recommandées {#recommended-toolchains}
 

--- a/content/docs/create-a-new-react-app.md
+++ b/content/docs/create-a-new-react-app.md
@@ -10,7 +10,7 @@ next: cdn-links.html
 
 Utilisez une boîte à outils intégrée pour la meilleure expérience utilisateur et développeur possible.
 
-Cette page décrit quelques chaînes d'outils populaires qui facilitent les tâches telles que :
+Cette page décrit quelques boîtes à outils populaires qui facilitent les tâches telles que :
 
 * Mise à l'échelle avec de nombreux fichiers et composants.
 * Utilisation de bibliothèques tierces depuis npm.

--- a/content/docs/create-a-new-react-app.md
+++ b/content/docs/create-a-new-react-app.md
@@ -8,7 +8,7 @@ prev: add-react-to-a-website.html
 next: cdn-links.html
 ---
 
-Utilisez une chaîne d'outils intégrée pour la meilleure expérience utilisateur et développeur possible.
+Utilisez une boîte à outils intégrée pour la meilleure expérience utilisateur et développeur possible.
 
 Cette page décrit quelques chaînes d'outils populaires qui facilitent les tâches telles que :
 

--- a/content/docs/create-a-new-react-app.md
+++ b/content/docs/create-a-new-react-app.md
@@ -89,6 +89,6 @@ Une chaîne d'outils de construction en JavaScript comprend généralement :
 
 * Un **compilateur** tel que [Babel](http://babeljs.io/). Il vous permet d'écrire du JavaScript moderne qui fonctionnera quand même dans les navigateurs les plus anciens.
 
-Si vous préférez configurer votre propre chaîne d'outils JavaScript à partir de rien, [consultez ce guide](https://blog.usejournal.com/creating-a-react-app-from-scratch-f3c693b84658) qui re-crée certaines des fonctionnalités de Create React App.
+Si vous préférez configurer votre propre chaîne d'outils JavaScript à partir de zéro, [jetez un œil à ce guide](https://blog.usejournal.com/creating-a-react-app-from-scratch-f3c693b84658) qui re-crée certaines des fonctionnalités de Create React App.
 
 N'oubliez pas de vous assurer que votre chaîne d'outils personnalisée [est correctement configurée pour la production](/docs/optimizing-performance.html#use-the-production-build).

--- a/content/docs/create-a-new-react-app.md
+++ b/content/docs/create-a-new-react-app.md
@@ -13,12 +13,12 @@ Utilisez une boîte à outils intégrée pour la meilleure expérience utilisate
 Cette page décrit quelques boîtes à outils populaires qui facilitent les tâches telles que :
 
 * La montée à l'échelle avec de nombreux fichiers et composants.
-* Utilisation de bibliothèques tierces depuis npm.
-* Détection précoce des erreurs courantes.
+* L'tilisation de bibliothèques tierces depuis npm.
+* La détection précoce des erreurs courantes.
 * L’édition à la volée du CSS et du JS en développement.
-* Optimisation pour la production.
+* L'optimisation pour la production.
 
-Les chaînes d'outils recommandées sur cette page **ne nécessitent aucune configuration pour démarrer**.
+Les boîtes à outils recommandées sur cette page **ne nécessitent aucune configuration pour démarrer**.
 
 ## Vous n'avez peut-être pas besoin d’une boîte à outils {#you-might-not-need-a-toolchain}
 
@@ -26,14 +26,14 @@ Si vous ne rencontrez pas les problèmes décrits ci-dessus ou si vous n'êtes p
 
 C'est également **la façon la plus simple d'intégrer React au sein d'un site web existant**. Vous pourrez toujours étendre votre outillage si ça vous semble utile !
 
-## Chaînes d'outils recommandées {#recommended-toolchains}
+## Boîtes à outils recommandées {#recommended-toolchains}
 
 L'équipe React recommande en premier lieu ces solutions :
 
 - Si vous **apprenez React** ou **créez une nouvelle [application web monopage](/docs/glossary.html#single-page-application)**, alors utilisez [Create React App](#create-react-app).
 - Si vous construisez un **site web rendu côté serveur avec Node.js**, essayez [Next.js](#nextjs).
 - Si vous construisez un **site web statique orienté contenu**, essayez [Gatsby](#gatsby).
-- Si vous construisez une **bibliothèque de composants** ou une **intégration avec du code déjà existant**, essayez [des chaînes d'outils plus flexibles](#more-flexible-toolchains).
+- Si vous construisez une **bibliothèque de composants** ou une **intégration avec du code déjà existant**, essayez [des boîtes à outils plus flexibles](#more-flexible-toolchains).
 
 ### Create React App {#create-react-app}
 
@@ -67,9 +67,9 @@ Apprenez Next.js grâce à [son guide officiel](https://nextjs.org/learn/).
 
 Apprenez Gatsby grâce à [son guide officiel](https://www.gatsbyjs.org/docs/) et à une [collection de kits de démarrage](https://www.gatsbyjs.org/docs/gatsby-starters/).
 
-### Chaînes d'outils plus flexibles {#more-flexible-toolchains}
+### Boîtes à outils plus flexibles {#more-flexible-toolchains}
 
-Les chaînes d'outils suivantes offrent plus de flexibilité et de choix. Nous les recommandons pour les utilisateurs expérimentés :
+Les boîtes à outils suivantes offrent plus de flexibilité et de choix. Nous les recommandons pour les utilisateurs expérimentés :
 
 - **[Neutrino](https://neutrinojs.org/)** combine la puissance de [webpack](https://webpack.js.org/) avec la simplicité des préréglages. Il inclut un préréglage pour les [applications React](https://neutrinojs.org/packages/react/) et les [composants React](https://neutrinojs.org/packages/react-components/).
 
@@ -79,9 +79,9 @@ Les chaînes d'outils suivantes offrent plus de flexibilité et de choix. Nous l
 
 - **[Razzle](https://github.com/jaredpalmer/razzle)** est un framework de rendu côté serveur qui ne requiert aucune configuration, mais offre plus de flexibilité que Next.js.
 
-## Créer une chaîne d'outils à partir de zéro {#creating-a-toolchain-from-scratch}
+## Créer une boîte à outils à partir de zéro {#creating-a-toolchain-from-scratch}
 
-Une chaîne d'outils de construction en JavaScript comprend généralement :
+Une boîte à outils de construction en JavaScript comprend généralement :
 
 * Un **gestionnaire de paquets**, tel que [Yarn](https://yarnpkg.com/) ou [npm](https://www.npmjs.com/). Il vous permet de tirer parti d'un vaste écosystème de paquets tiers, et de les installer ou les mettre à jour facilement.
 
@@ -89,6 +89,6 @@ Une chaîne d'outils de construction en JavaScript comprend généralement :
 
 * Un **compilateur** tel que [Babel](http://babeljs.io/). Il vous permet d'écrire du JavaScript moderne qui fonctionnera quand même dans les navigateurs les plus anciens.
 
-Si vous préférez configurer votre propre chaîne d'outils JavaScript à partir de zéro, [jetez un œil à ce guide](https://blog.usejournal.com/creating-a-react-app-from-scratch-f3c693b84658) qui re-crée certaines des fonctionnalités de Create React App.
+Si vous préférez configurer votre propre boîte à outils JavaScript à partir de zéro, [jetez un œil à ce guide](https://blog.usejournal.com/creating-a-react-app-from-scratch-f3c693b84658) qui re-crée certaines des fonctionnalités de Create React App.
 
 Pensez à vous assurer que votre outillage personnalisé [est correctement configuré pour la production](/docs/optimizing-performance.html#use-the-production-build).

--- a/content/docs/create-a-new-react-app.md
+++ b/content/docs/create-a-new-react-app.md
@@ -15,7 +15,7 @@ Cette page décrit quelques boîtes à outils populaires qui facilitent les tâc
 * La montée à l'échelle avec de nombreux fichiers et composants.
 * Utilisation de bibliothèques tierces depuis npm.
 * Détection précoce des erreurs courantes.
-* Édition en direct du CSS et du JS en développement.
+* L’édition à la volée du CSS et du JS en développement.
 * Optimisation pour la production.
 
 Les chaînes d'outils recommandées sur cette page **ne nécessitent aucune configuration pour démarrer**.

--- a/content/docs/create-a-new-react-app.md
+++ b/content/docs/create-a-new-react-app.md
@@ -85,7 +85,7 @@ Une chaîne d'outils de construction en JavaScript comprend généralement :
 
 * Un **gestionnaire de paquets**, tel que [Yarn](https://yarnpkg.com/) ou [npm](https://www.npmjs.com/). Il vous permet de tirer parti d'un vaste écosystème de paquets tiers, et de les installer ou les mettre à jour facilement.
 
-* Un **empaqueteur**, tel que [webpack](https://webpack.js.org/) ou [Parcel](https://parceljs.org/). Il vous permet d'écrire du code modulaire et de le regrouper en petits paquets permettant d'optimiser le temps de chargement.
+* Un **_bundler_**, tel que [webpack](https://webpack.js.org/) ou [Parcel](https://parceljs.org/). Il vous permet d'écrire du code modulaire et de le regrouper en petits paquets permettant d'optimiser le temps de chargement.
 
 * Un **compilateur** tel que [Babel](http://babeljs.io/). Il vous permet d'écrire du JavaScript moderne qui continuera à fonctionner dans les navigateurs les plus anciens.
 

--- a/content/docs/create-a-new-react-app.md
+++ b/content/docs/create-a-new-react-app.md
@@ -51,7 +51,7 @@ npm start
 >
 > `npx` sur la première ligne n'est pas une faute de frappe -- c'est un [exécuteur de paquets qui est inclus dans npm 5.2+](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b).
 
-Create React App ne prend pas en charge la logique côté serveur ni les bases de données ; il crée simplement une chaîne de construction pour la partie frontale, de sorte que vous pouvez utiliser le serveur de votre choix. Sous le capot, it utilise [Babel](http://babeljs.io/) et [webpack](https://webpack.js.org/), mais vous n'avez pas besoin de connaître ces outils.
+Create React App ne prend pas en charge la logique côté serveur ni les bases de données ; il crée simplement une chaîne de construction pour la partie frontale, de sorte que vous pouvez utiliser le serveur de votre choix. Sous le capot, il utilise [Babel](http://babeljs.io/) et [webpack](https://webpack.js.org/), mais vous n'avez pas besoin de connaître ces outils.
 
 Lorsque vous êtes prêt·e à déployer en production, exécutez `npm run build` pour créer une version optimisée de votre application dans le répertoire `build`. Vous pouvez en apprendre davantage sur Create React App [dans son README](https://github.com/facebookincubator/create-react-app#create-react-app-) et son [guide utilisateur](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#table-of-contents).
 
@@ -72,11 +72,8 @@ Apprenez Gatsby grâce à [son guide officiel](https://www.gatsbyjs.org/docs/) e
 Les boîtes à outils suivantes offrent plus de flexibilité et de choix. Nous les recommandons pour les utilisateurs expérimentés :
 
 - **[Neutrino](https://neutrinojs.org/)** combine la puissance de [webpack](https://webpack.js.org/) avec la simplicité des préréglages. Il inclut un préréglage pour les [applications React](https://neutrinojs.org/packages/react/) et les [composants React](https://neutrinojs.org/packages/react-components/).
-
 - **[nwb](https://github.com/insin/nwb)** est particulièrement utile pour [publier des composants React sur npm](https://github.com/insin/nwb/blob/master/docs/guides/ReactComponents.md#developing-react-components-and-libraries-with-nwb). Il [peut également être utilisé](https://github.com/insin/nwb/blob/master/docs/guides/ReactApps.md#developing-react-apps-with-nwb) pour créer des applications React.
-
 - **[Parcel](https://parceljs.org/)** est un *bundler* d'applications web rapide et sans configuration qui [fonctionne avec React](https://parceljs.org/recipes.html#react).
-
 - **[Razzle](https://github.com/jaredpalmer/razzle)** est un framework de rendu côté serveur qui ne requiert aucune configuration, mais offre plus de flexibilité que Next.js.
 
 ## Créer une boîte à outils à partir de zéro {#creating-a-toolchain-from-scratch}
@@ -84,9 +81,7 @@ Les boîtes à outils suivantes offrent plus de flexibilité et de choix. Nous l
 Une boîte à outils de construction en JavaScript comprend généralement :
 
 * Un **gestionnaire de paquets**, tel que [Yarn](https://yarnpkg.com/) ou [npm](https://www.npmjs.com/). Il vous permet de tirer parti d'un vaste écosystème de paquets tiers, et de les installer ou les mettre à jour facilement.
-
 * Un **_bundler_**, tel que [webpack](https://webpack.js.org/) ou [Parcel](https://parceljs.org/). Il vous permet d'écrire du code modulaire et de le regrouper en petits paquets permettant d'optimiser le temps de chargement.
-
 * Un **compilateur** tel que [Babel](http://babeljs.io/). Il vous permet d'écrire du JavaScript moderne qui fonctionnera quand même dans les navigateurs les plus anciens.
 
 Si vous préférez configurer votre propre boîte à outils JavaScript à partir de zéro, [jetez un œil à ce guide](https://blog.usejournal.com/creating-a-react-app-from-scratch-f3c693b84658) qui re-crée certaines des fonctionnalités de Create React App.

--- a/content/docs/create-a-new-react-app.md
+++ b/content/docs/create-a-new-react-app.md
@@ -20,7 +20,7 @@ Cette page décrit quelques boîtes à outils populaires qui facilitent les tâc
 
 Les chaînes d'outils recommandées sur cette page **ne nécessitent aucune configuration pour démarrer**.
 
-## Vous n'avez probablement pas besoin de chaînes d'outils {#you-might-not-need-a-toolchain}
+## Vous n'avez peut-être pas besoin d’une boîte à outils {#you-might-not-need-a-toolchain}
 
 Si vous ne rencontrez pas les problèmes décrits ci-dessus ou si vous n'êtes pas encore à l'aise avec l'utilisation d'outils JavaScript, envisagez [d'ajouter React comme une simple balise `<script>` sur une page HTML](/docs/add-react-to-a-website.html), éventuellement [avec du JSX](/docs/add-react-to-a-website.html#optional-try-react-with-jsx).
 

--- a/content/docs/create-a-new-react-app.md
+++ b/content/docs/create-a-new-react-app.md
@@ -12,7 +12,7 @@ Utilisez une boîte à outils intégrée pour la meilleure expérience utilisate
 
 Cette page décrit quelques boîtes à outils populaires qui facilitent les tâches telles que :
 
-* Mise à l'échelle avec de nombreux fichiers et composants.
+* La montée à l'échelle avec de nombreux fichiers et composants.
 * Utilisation de bibliothèques tierces depuis npm.
 * Détection précoce des erreurs courantes.
 * Édition en direct du CSS et du JS en développement.

--- a/content/docs/create-a-new-react-app.md
+++ b/content/docs/create-a-new-react-app.md
@@ -91,4 +91,4 @@ Une chaîne d'outils de construction en JavaScript comprend généralement :
 
 Si vous préférez configurer votre propre chaîne d'outils JavaScript à partir de zéro, [jetez un œil à ce guide](https://blog.usejournal.com/creating-a-react-app-from-scratch-f3c693b84658) qui re-crée certaines des fonctionnalités de Create React App.
 
-N'oubliez pas de vous assurer que votre chaîne d'outils personnalisée [est correctement configurée pour la production](/docs/optimizing-performance.html#use-the-production-build).
+Pensez à vous assurer que votre outillage personnalisé [est correctement configuré pour la production](/docs/optimizing-performance.html#use-the-production-build).

--- a/content/docs/create-a-new-react-app.md
+++ b/content/docs/create-a-new-react-app.md
@@ -32,14 +32,14 @@ L'équipe React recommande en premier lieu ces solutions :
 
 - Si vous **apprenez React** ou **créez une nouvelle [application web monopage](/docs/glossary.html#single-page-application)**, alors utilisez [Create React App](#create-react-app).
 - Si vous construisez un **site web rendu côté serveur avec Node.js**, essayez [Next.js](#nextjs).
-- Si vous construisez un **site web statique orienté sur le contenu**, essayez [Gatsby](#gatsby).
+- Si vous construisez un **site web statique orienté contenu**, essayez [Gatsby](#gatsby).
 - Si vous construisez une **bibliothèque de composants** ou une **intégration avec du code déjà existant**, essayez [des chaînes d'outils plus flexibles](#more-flexible-toolchains).
 
 ### Create React App {#create-react-app}
 
 [Create React App](http://github.com/facebookincubator/create-react-app) est un environnement confortable pour **apprendre React**, et constitue la meilleure option pour démarrer **une nouvelle [application web monopage](/docs/glossary.html#single-page-application)** en React.
 
-Il configure votre environnement de développement de façon à vous permettre d'utiliser les dernières fonctionnalités de JavaScript, propose une bonne expérience développeur et optimise votre application pour la production. Vous aurez besoin de Node >= 6 et npm >= 5.2 sur votre machine. Pour créer un projet, exécutez :
+Il configure votre environnement de développement de façon à vous permettre d'utiliser les dernières fonctionnalités de JavaScript, propose une expérience développeur agréable et optimise votre application pour la production. Vous aurez besoin de Node >= 6 et de npm >= 5.2 sur votre machine. Pour créer un projet, exécutez :
 
 ```bash
 npx create-react-app mon-app
@@ -47,17 +47,17 @@ cd mon-app
 npm start
 ```
 
->Note
+> Remaque :
 >
->`npx` sur la première ligne n'est pas une faute de frappe -- c'est un [exécuteur de paquets qui est inclut dans npm 5.2+](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b).
+> `npx` sur la première ligne n'est pas une faute de frappe -- c'est un [exécuteur de paquets qui est inclus dans npm 5.2+](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b).
 
-Create React App ne prend pas en charge la logique côté serveur ni les bases de données ; il crée simplement une chaîne de construction pour la partie frontale, de telle façon que vous pouvez utiliser n'importe quel serveur de votre choix. Sous le capot, it utilise [Babel](http://babeljs.io/) et [webpack](https://webpack.js.org/), mais vous n'avez pas besoin de connaître ces outils.
+Create React App ne prend pas en charge la logique côté serveur ni les bases de données ; il crée simplement une chaîne de construction pour la partie frontale, de sorte que vous pouvez utiliser le serveur de votre choix. Sous le capot, it utilise [Babel](http://babeljs.io/) et [webpack](https://webpack.js.org/), mais vous n'avez pas besoin de connaître ces outils.
 
-Lorsque vous êtes prêt à déployer en production, exécuter `npm run build` créera une version optimisée de votre application dans le répertoire `build`. Vous pouvez en apprendre davantage sur Create React App [depuis son README](https://github.com/facebookincubator/create-react-app#create-react-app-) et son [guide utilisateur](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#table-of-contents).
+Lorsque vous êtes prêt·e à déployer en production, exécutez `npm run build` pour créer une version optimisée de votre application dans le répertoire `build`. Vous pouvez en apprendre davantage sur Create React App [dans son README](https://github.com/facebookincubator/create-react-app#create-react-app-) et son [guide utilisateur](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#table-of-contents).
 
 ### Next.js {#nextjs}
 
-[Next.js](https://nextjs.org/) est un framework populaire et léger pour les **applications statiques rendues côté serveur** construites avec React. Il inclut des solutions prêtes à l'emploi pour le **style et le routage**, et suppose que vous utilisez [Node.js](https://nodejs.org/) comme environnement de serveur.
+[Next.js](https://nextjs.org/) est un framework populaire et léger pour les **applications statiques rendues côté serveur** construites avec React. Il fournit des solutions prêtes à l'emploi pour **les styles et le routage**, et suppose que vous utilisez [Node.js](https://nodejs.org/) comme environnement serveur.
 
 Apprenez Next.js grâce à [son guide officiel](https://nextjs.org/learn/).
 
@@ -73,13 +73,13 @@ Les chaînes d'outils suivantes offrent plus de flexibilité et de choix. Nous l
 
 - **[Neutrino](https://neutrinojs.org/)** combine la puissance de [webpack](https://webpack.js.org/) avec la simplicité des préréglages. Il inclut un préréglage pour les [applications React](https://neutrinojs.org/packages/react/) et les [composants React](https://neutrinojs.org/packages/react-components/).
 
-- **[nwb](https://github.com/insin/nwb)** est particulièrement utile pour [publier des composants React pour npm](https://github.com/insin/nwb/blob/master/docs/guides/ReactComponents.md#developing-react-components-and-libraries-with-nwb). Il [peut également être utilisé](https://github.com/insin/nwb/blob/master/docs/guides/ReactApps.md#developing-react-apps-with-nwb) pour créer des applications React.
+- **[nwb](https://github.com/insin/nwb)** est particulièrement utile pour [publier des composants React sur npm](https://github.com/insin/nwb/blob/master/docs/guides/ReactComponents.md#developing-react-components-and-libraries-with-nwb). Il [peut également être utilisé](https://github.com/insin/nwb/blob/master/docs/guides/ReactApps.md#developing-react-apps-with-nwb) pour créer des applications React.
 
-- **[Parcel](https://parceljs.org/)** est un empaqueteur d'applications web rapide et sans configuration qui [fonctionne avec React](https://parceljs.org/recipes.html#react).
+- **[Parcel](https://parceljs.org/)** est un *bundler* d'applications web rapide et sans configuration qui [fonctionne avec React](https://parceljs.org/recipes.html#react).
 
 - **[Razzle](https://github.com/jaredpalmer/razzle)** est un framework de rendu côté serveur qui ne requiert aucune configuration, mais offre plus de flexibilité que Next.js.
 
-## Créer une chaîne d'outils à partir de rien {#creating-a-toolchain-from-scratch}
+## Créer une chaîne d'outils à partir de zéro {#creating-a-toolchain-from-scratch}
 
 Une chaîne d'outils de construction en JavaScript comprend généralement :
 

--- a/content/docs/create-a-new-react-app.md
+++ b/content/docs/create-a-new-react-app.md
@@ -1,6 +1,6 @@
 ---
 id: create-a-new-react-app
-title: Créer une nouvelle application React
+title: Créer une nouvelle appli React
 permalink: docs/create-a-new-react-app.html
 redirect_from:
   - "docs/add-react-to-a-new-app.html"

--- a/content/docs/create-a-new-react-app.md
+++ b/content/docs/create-a-new-react-app.md
@@ -37,7 +37,7 @@ L'équipe React recommande en premier lieu ces solutions :
 
 ### Create React App {#create-react-app}
 
-[Create React App](http://github.com/facebookincubator/create-react-app) est un environnement confortable pour **apprendre React**, et représente la meilleure option pour démarrer **une nouvelle [application web monopage](/docs/glossary.html#single-page-application)** en React.
+[Create React App](http://github.com/facebookincubator/create-react-app) est un environnement confortable pour **apprendre React**, et constitue la meilleure option pour démarrer **une nouvelle [application web monopage](/docs/glossary.html#single-page-application)** en React.
 
 Il configure votre environnement de développement de façon à vous permettre d'utiliser les dernières fonctionnalités de JavaScript, propose une bonne expérience développeur et optimise votre application pour la production. Vous aurez besoin de Node >= 6 et npm >= 5.2 sur votre machine. Pour créer un projet, exécutez :
 

--- a/content/docs/create-a-new-react-app.md
+++ b/content/docs/create-a-new-react-app.md
@@ -1,6 +1,6 @@
 ---
 id: create-a-new-react-app
-title: Create a New React App
+title: Créer une nouvelle application React
 permalink: docs/create-a-new-react-app.html
 redirect_from:
   - "docs/add-react-to-a-new-app.html"
@@ -8,87 +8,87 @@ prev: add-react-to-a-website.html
 next: cdn-links.html
 ---
 
-Use an integrated toolchain for the best user and developer experience.
+Utilisez une chaîne d'outils intégrée pour la meilleure expérience utilisateur et développeur possible.
 
-This page describes a few popular React toolchains which help with tasks like:
+Cette page décrit quelques chaînes d'outils populaires qui facilitent les tâches telles que :
 
-* Scaling to many files and components.
-* Using third-party libraries from npm.
-* Detecting common mistakes early.
-* Live-editing CSS and JS in development.
-* Optimizing the output for production.
+* Mise à l'échelle avec de nombreux fichiers et composants.
+* Utilisation de bibliothèques tierces depuis npm.
+* Détection précoce des erreurs courantes.
+* Édition en direct du CSS et du JS en développement.
+* Optimisation pour la production.
 
-The toolchains recommended on this page **don't require configuration to get started**.
+Les chaînes d'outils recommandées sur cette page **ne nécessitent aucune configuration pour démarrer**.
 
-## You Might Not Need a Toolchain {#you-might-not-need-a-toolchain}
+## Vous n'avez probablement pas besoin de chaînes d'outils {#you-might-not-need-a-toolchain}
 
-If you don't experience the problems described above or don't feel comfortable using JavaScript tools yet, consider [adding React as a plain `<script>` tag on an HTML page](/docs/add-react-to-a-website.html), optionally [with JSX](/docs/add-react-to-a-website.html#optional-try-react-with-jsx).
+Si vous ne rencontrez pas les problèmes décrits ci-dessus ou si vous n'êtes pas encore à l'aise avec l'utilisation d'outils JavaScript, envisagez [d'ajouter React comme une simple balise `<script>` sur une page HTML](/docs/add-react-to-a-website.html), éventuellement [avec du JSX](/docs/add-react-to-a-website.html#optional-try-react-with-jsx).
 
-This is also **the easiest way to integrate React into an existing website.** You can always add a larger toolchain if you find it helpful!
+C'est également **la façon la plus simple d'intégrer React au sein d'un site web existant**. Vous pourrez toujours étendre votre chaîne d'outils si vous trouvez cela utile !
 
-## Recommended Toolchains {#recommended-toolchains}
+## Chaînes d'outils recommandées {#recommended-toolchains}
 
-The React team primarily recommends these solutions:
+L'équipe React recommande en premier lieu ces solutions :
 
-- If you're **learning React** or **creating a new [single-page](/docs/glossary.html#single-page-application) app,** use [Create React App](#create-react-app).
-- If you're building a **server-rendered website with Node.js,** try [Next.js](#nextjs).
-- If you're building a **static content-oriented website,** try [Gatsby](#gatsby).
-- If you're building a **component library** or **integrating with an existing codebase**, try [More Flexible Toolchains](#more-flexible-toolchains).
+- Si vous **apprenez React** ou **créez une nouvelle [application web monopage](/docs/glossary.html#single-page-application)**, alors utilisez [Create React App](#create-react-app).
+- Si vous construisez un **site web rendu côté serveur avec Node.js**, essayez [Next.js](#nextjs).
+- Si vous construisez un **site web statique orienté sur le contenu**, essayez [Gatsby](#gatsby).
+- Si vous construisez une **bibliothèque de composants** ou une **intégration avec du code déjà existant**, essayez [des chaînes d'outils plus flexibles](#more-flexible-toolchains).
 
 ### Create React App {#create-react-app}
 
-[Create React App](http://github.com/facebookincubator/create-react-app) is a comfortable environment for **learning React**, and is the best way to start building **a new [single-page](/docs/glossary.html#single-page-application) application** in React.
+[Create React App](http://github.com/facebookincubator/create-react-app) est un environnement confortable pour **apprendre React**, et représente la meilleure option pour démarrer **une nouvelle [application web monopage](/docs/glossary.html#single-page-application)** en React.
 
-It sets up your development environment so that you can use the latest JavaScript features, provides a nice developer experience, and optimizes your app for production. You’ll need to have Node >= 6 and npm >= 5.2 on your machine. To create a project, run:
+Il configure votre environnement de développement de façon à vous permettre d'utiliser les dernières fonctionnalités de JavaScript, propose une bonne expérience développeur et optimise votre application pour la production. Vous aurez besoin de Node >= 6 et npm >= 5.2 sur votre machine. Pour créer un projet, exécutez :
 
 ```bash
-npx create-react-app my-app
-cd my-app
+npx create-react-app mon-app
+cd mon-app
 npm start
 ```
 
 >Note
 >
->`npx` on the first line is not a typo -- it's a [package runner tool that comes with npm 5.2+](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b).
+>`npx` sur la première ligne n'est pas une faute de frappe -- c'est un [exécuteur de paquets qui est inclut dans npm 5.2+](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b).
 
-Create React App doesn't handle backend logic or databases; it just creates a frontend build pipeline, so you can use it with any backend you want. Under the hood, it uses [Babel](http://babeljs.io/) and [webpack](https://webpack.js.org/), but you don't need to know anything about them.
+Create React App ne prend pas en charge la logique côté serveur ni les bases de données ; il crée simplement une chaîne de construction pour la partie frontale, de telle façon que vous pouvez utiliser n'importe quel serveur de votre choix. Sous le capot, it utilise [Babel](http://babeljs.io/) et [webpack](https://webpack.js.org/), mais vous n'avez pas besoin de connaître ces outils.
 
-When you're ready to deploy to production, running `npm run build` will create an optimized build of your app in the `build` folder. You can learn more about Create React App [from its README](https://github.com/facebookincubator/create-react-app#create-react-app-) and the [User Guide](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#table-of-contents).
+Lorsque vous êtes prêt à déployer en production, exécuter `npm run build` créera une version optimisée de votre application dans le répertoire `build`. Vous pouvez en apprendre davantage sur Create React App [depuis son README](https://github.com/facebookincubator/create-react-app#create-react-app-) et son [guide utilisateur](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#table-of-contents).
 
 ### Next.js {#nextjs}
 
-[Next.js](https://nextjs.org/) is a popular and lightweight framework for **static and server‑rendered applications** built with React. It includes **styling and routing solutions** out of the box, and assumes that you're using [Node.js](https://nodejs.org/) as the server environment.
+[Next.js](https://nextjs.org/) est un framework populaire et léger pour les **applications statiques rendues côté serveur** construites avec React. Il inclut des solutions prêtes à l'emploi pour le **style et le routage**, et suppose que vous utilisez [Node.js](https://nodejs.org/) comme environnement de serveur.
 
-Learn Next.js from [its official guide](https://nextjs.org/learn/).
+Apprenez Next.js grâce à [son guide officiel](https://nextjs.org/learn/).
 
 ### Gatsby {#gatsby}
 
-[Gatsby](https://www.gatsbyjs.org/) is the best way to create **static websites** with React. It lets you use React components, but outputs pre-rendered HTML and CSS to guarantee the fastest load time.
+[Gatsby](https://www.gatsbyjs.org/) est la meilleure option pour créer des **sites web statiques** avec React. Il vous permet d'utiliser des composants React, mais génère du HTML et du CSS pré-rendus afin de garantir le temps de chargement le plus rapide.
 
-Learn Gatsby from [its official guide](https://www.gatsbyjs.org/docs/) and a [gallery of starter kits](https://www.gatsbyjs.org/docs/gatsby-starters/).
+Apprenez Gatsby grâce à [son guide officiel](https://www.gatsbyjs.org/docs/) et à une [collection de kits de démarrage](https://www.gatsbyjs.org/docs/gatsby-starters/).
 
-### More Flexible Toolchains {#more-flexible-toolchains}
+### Chaînes d'outils plus flexibles {#more-flexible-toolchains}
 
-The following toolchains offer more flexiblity and choice. We recommend them to more experienced users:
+Les chaînes d'outils suivantes offrent plus de flexibilité et de choix. Nous les recommandons pour les utilisateurs expérimentés :
 
-- **[Neutrino](https://neutrinojs.org/)** combines the power of [webpack](https://webpack.js.org/) with the simplicity of presets, and includes a preset for [React apps](https://neutrinojs.org/packages/react/) and [React components](https://neutrinojs.org/packages/react-components/).
+- **[Neutrino](https://neutrinojs.org/)** combine la puissance de [webpack](https://webpack.js.org/) avec la simplicité des préréglages. Il inclut un préréglage pour les [applications React](https://neutrinojs.org/packages/react/) et les [composants React](https://neutrinojs.org/packages/react-components/).
 
-- **[nwb](https://github.com/insin/nwb)** is particularly great for [publishing React components for npm](https://github.com/insin/nwb/blob/master/docs/guides/ReactComponents.md#developing-react-components-and-libraries-with-nwb). It [can be used](https://github.com/insin/nwb/blob/master/docs/guides/ReactApps.md#developing-react-apps-with-nwb) for creating React apps, too. 
+- **[nwb](https://github.com/insin/nwb)** est particulièrement utile pour [publier des composants React pour npm](https://github.com/insin/nwb/blob/master/docs/guides/ReactComponents.md#developing-react-components-and-libraries-with-nwb). Il [peut également être utilisé](https://github.com/insin/nwb/blob/master/docs/guides/ReactApps.md#developing-react-apps-with-nwb) pour créer des applications React.
 
-- **[Parcel](https://parceljs.org/)** is a fast, zero configuration web application bundler that [works with React](https://parceljs.org/recipes.html#react).
+- **[Parcel](https://parceljs.org/)** est un empaqueteur d'applications web rapide et sans configuration qui [fonctionne avec React](https://parceljs.org/recipes.html#react).
 
-- **[Razzle](https://github.com/jaredpalmer/razzle)** is a server-rendering framework that doesn't require any configuration, but offers more flexibility than Next.js.
+- **[Razzle](https://github.com/jaredpalmer/razzle)** est un framework de rendu côté serveur qui ne requiert aucune configuration, mais offre plus de flexibilité que Next.js.
 
-## Creating a Toolchain from Scratch {#creating-a-toolchain-from-scratch}
+## Créer une chaîne d'outils à partir de rien {#creating-a-toolchain-from-scratch}
 
-A JavaScript build toolchain typically consists of:
+Une chaîne d'outils de construction en JavaScript consiste généralement en :
 
-* A **package manager**, such as [Yarn](https://yarnpkg.com/) or [npm](https://www.npmjs.com/). It lets you take advantage of a vast ecosystem of third-party packages, and easily install or update them.
+* Un **gestionnaire de paquets**, tel que [Yarn](https://yarnpkg.com/) ou [npm](https://www.npmjs.com/). Il vous permet de tirer parti d'un vaste écosystème de paquets tiers, et de les installer ou les mettre à jour facilement.
 
-* A **bundler**, such as [webpack](https://webpack.js.org/) or [Parcel](https://parceljs.org/). It lets you write modular code and bundle it together into small packages to optimize load time.
+* Un **empaqueteur**, tel que [webpack](https://webpack.js.org/) ou [Parcel](https://parceljs.org/). Il vous permet d'écrire du code modulaire et de le regrouper en petits paquets permettant d'optimiser le temps de chargement.
 
-* A **compiler** such as [Babel](http://babeljs.io/). It lets you write modern JavaScript code that still works in older browsers.
+* Un **compilateur** tel que [Babel](http://babeljs.io/). Il vous permet d'écrire du JavaScript moderne qui continuera à fonctionner dans les navigateurs les plus anciens.
 
-If you prefer to set up your own JavaScript toolchain from scratch, [check out this guide](https://blog.usejournal.com/creating-a-react-app-from-scratch-f3c693b84658) that re-creates some of the Create React App functionality.
+Si vous préférez configurer votre propre chaîne d'outils JavaScript à partir de rien, [consultez ce guide](https://blog.usejournal.com/creating-a-react-app-from-scratch-f3c693b84658) qui re-crée certaines des fonctionnalités de Create React App.
 
-Don't forget to ensure your custom toolchain [is correctly set up for production](/docs/optimizing-performance.html#use-the-production-build).
+N'oubliez pas de vous assurer que votre chaîne d'outils personnalisée [est correctement configurée pour la production](/docs/optimizing-performance.html#use-the-production-build).

--- a/content/docs/create-a-new-react-app.md
+++ b/content/docs/create-a-new-react-app.md
@@ -13,7 +13,7 @@ Utilisez une boîte à outils intégrée pour la meilleure expérience utilisate
 Cette page décrit quelques boîtes à outils populaires qui facilitent les tâches telles que :
 
 * La montée à l'échelle avec de nombreux fichiers et composants.
-* L'tilisation de bibliothèques tierces depuis npm.
+* L'utilisation de bibliothèques tierces depuis npm.
 * La détection précoce des erreurs courantes.
 * L’édition à la volée du CSS et du JS en développement.
 * L'optimisation pour la production.

--- a/content/docs/create-a-new-react-app.md
+++ b/content/docs/create-a-new-react-app.md
@@ -87,7 +87,7 @@ Une chaîne d'outils de construction en JavaScript comprend généralement :
 
 * Un **_bundler_**, tel que [webpack](https://webpack.js.org/) ou [Parcel](https://parceljs.org/). Il vous permet d'écrire du code modulaire et de le regrouper en petits paquets permettant d'optimiser le temps de chargement.
 
-* Un **compilateur** tel que [Babel](http://babeljs.io/). Il vous permet d'écrire du JavaScript moderne qui continuera à fonctionner dans les navigateurs les plus anciens.
+* Un **compilateur** tel que [Babel](http://babeljs.io/). Il vous permet d'écrire du JavaScript moderne qui fonctionnera quand même dans les navigateurs les plus anciens.
 
 Si vous préférez configurer votre propre chaîne d'outils JavaScript à partir de rien, [consultez ce guide](https://blog.usejournal.com/creating-a-react-app-from-scratch-f3c693b84658) qui re-crée certaines des fonctionnalités de Create React App.
 


### PR DESCRIPTION
Bonjour,

Voici ma traduction pour la page [Create a New React App](https://reactjs.org/docs/create-a-new-react-app.html).

Mes remarques / questions :

1. Y a t-il une bonne traduction pour `bundler` ? J'ai trouvé `empaqueteur` sur MDN, mais ils [ont aussi](https://developer.mozilla.org/fr/docs/Glossaire/Tree_shaking) `gestionnaires de regroupements de modules`, que je n'aime pas trop...
2. `Toolchain` a été traduit en `chaîne d'outils`. Existe-t-il une meilleure traduction ?
