### PR TITLE
Error boundaries

### DIFF
--- a/content/docs/error-boundaries.md
+++ b/content/docs/error-boundaries.md
@@ -8,7 +8,7 @@ Auparavant, les erreurs JavaScript au sein des composants avaient l'habitude de 
 
 ## L'arrivée des périmètres d'erreurs {#introducing-error-boundaries}
 
-Une erreur JavaScript au sein d’une partie de l'interface utilisateur (UI) ne devrait pas casser l'ensemble de l'application. Pour résoudre ce problème pour les utilisateurs de React, React 16 a introduit un nouveau concept appelé « Périmètres d’erreurs » *(Error Boundaries, NdT)*.
+Une erreur JavaScript au sein d’une partie de l'interface utilisateur (UI) ne devrait pas casser l'ensemble de l'application. Pour résoudre ce problème, React 16 a introduit un nouveau concept appelé « Périmètres d’erreurs » *(Error Boundaries, NdT)*.
 
 Les périmètres d'erreurs sont des composants React qui **interceptent les erreurs JavaScript n'importe où au sein de leur arbre de composants enfants, enregistrent ces erreurs, et affichent une UI de repli** à la place de l'arbre de composants qui a planté. Les périmètres d'erreurs interceptent les erreurs survenant au rendu, dans les méthodes de cycle de vie, ainsi que dans les constructeurs de tous les éléments de leur arborescence.
 
@@ -46,7 +46,7 @@ class ErrorBoundary extends React.Component {
       return <h1>Something went wrong.</h1>;
     }
 
-    return this.props.children; 
+    return this.props.children;
   }
 }
 ```
@@ -70,14 +70,14 @@ Jetez un coup d'œil sur [cet exemple de déclaration et d'utilisation d'un pér
 
 ## Où placer les périmètres d'erreurs ? {#where-to-place-error-boundaries}
 
-La granularité des périmètres d'erreurs est à votre discrétion. Vous pourriez enrober les composants racines de routage pour afficher à l'utilisateur un message du type « Quelque chose s'est mal passé », à l'image de ce qui est souvent fait par les frameworks côté serveur. Vous pourriez aussi enrober des éléments d'interface précis avec un périmètre d'erreur afin de les empêcher de planter le reste de l'application.
+La granularité des périmètres d'erreurs est à votre discrétion. Vous pourriez enrober les composants racines de routage pour afficher à l'utilisateur un message du type « Quelque chose s'est mal passé », à l'image de ce qui est souvent fait par les frameworks côté serveur. Vous pourriez aussi enrober des éléments d'interface précis avec un périmètre d'erreur afin de les empêcher de planter le reste de l'application.
 
 
 ## Nouveau comportement pour les erreurs non-rattrapées {#new-behavior-for-uncaught-errors}
 
 Ce changement a un impact important. **À compter de React 16, les erreurs qui ne sont pas interceptées par un périmètre d'erreur entraîneront le démontage de l'intégralité de l'arbre des composants**.
 
-Cette décision a été débattue, mais d'expérience nous avons remarqué qu'il est bien pire de laisser en place une interface corrompue que de la supprimer complètement. Par exemple, dans un produit tel que Messenger, laisser une interface dégradée visible peut amener l'utilisateur à envoyer un message à la mauvaise personne. De la même façon, pour une application de paiement, afficher un mauvais montant est bien pire que de ne rien afficher du tout.
+Cette décision a été débattue, mais l'expérience nous a montré qu'il est bien pire de laisser en place une interface corrompue que de la supprimer complètement. Par exemple, dans un produit tel que Messenger, laisser visible une interface dégradée peut amener l'utilisateur à envoyer un message à la mauvaise personne. De la même façon, pour une application de paiement, afficher un mauvais montant est bien pire que de ne rien afficher du tout.
 
 Cette modification signifie que lorsque vous migrez vers React 16, vous découvrirez probablement des plantages dans votre application qui étaient jusque-là passés inaperçus. L'ajout de périmètres d'erreurs permet d'offrir une meilleure expérience utilisateur en cas de problème.
 
@@ -162,4 +162,4 @@ Remarquez que l'exemple ci-dessus illustre un comportement JavaScript classique 
 
 React 15 disposait d'une prise en charge très limitée des périmètres d'erreurs sous un nom de méthode différent : `unstable_handleError`. Cette méthode ne fonctionne plus, et vous devrez la remplacer par `componentDidCatch` dans votre code à partir de la première version bêta de React 16.
 
-Pour ce changement, nous fournissons un [codemod](https://github.com/reactjs/react-codemod#error-boundaries) pour migrer automatiquement votre code.
+Pour ce changement, nous fournissons un [codemod](https://github.com/reactjs/react-codemod#error-boundaries) qui vous permet de migrer automatiquement votre code.

--- a/content/docs/error-boundaries.md
+++ b/content/docs/error-boundaries.md
@@ -4,7 +4,7 @@ title: Périmètres d'erreurs
 permalink: docs/error-boundaries.html
 ---
 
-Auparavant, les erreurs JavaScript au sein des composants avaient l'habitude de corrompre l'état interne de React, et de causer des [erreurs](https://github.com/facebook/react/issues/4026) [assez](https://github.com/facebook/react/issues/6895) [incompréhensibles](https://github.com/facebook/react/issues/8579) lors des rendus suivants. Ces erreurs étaient toujours causées par une erreur antérieure dans le code applicatif, et React ne proposait alors aucun moyen de les gérer correctement dans les composants, et n'était pas capable de se rétablir.
+Auparavant, les erreurs JavaScript au sein des composants avaient l'habitude de corrompre l'état interne de React, et de causer des [erreurs](https://github.com/facebook/react/issues/4026) [assez](https://github.com/facebook/react/issues/6895) [incompréhensibles](https://github.com/facebook/react/issues/8579) lors des rendus suivants. Ces erreurs étaient toujours causées par une erreur antérieure dans le code applicatif et comme React ne proposait alors aucun moyen de les gérer correctement dans les composants, il n'avait pas la possibilité de se rétablir.
 
 ## L'arrivée des périmètres d'erreurs {#introducing-error-boundaries}
 
@@ -36,7 +36,7 @@ class ErrorBoundary extends React.Component {
   }
 
   componentDidCatch(error, info) {
-    // Vous pouvez aussi tracer l'erreur au sein d'un service de rapport.
+    // Vous pouvez aussi enregistrer l'erreur au sein d'un service de rapport.
     logErrorToMyService(error, info);
   }
 
@@ -65,25 +65,25 @@ Remarquez que **les périmètres d'erreurs ne détectent que les erreurs présen
 
 ## Démonstration {#live-demo}
 
-Jetez un œil sur [cet exemple de déclaration et d'usage d'un périmètre d'erreur](https://codepen.io/gaearon/pen/wqvxGa?editors=0010) avec [React 16](/blog/2017/09/26/react-v16.0.html).
+Jetez un coup d'œil sur [cet exemple de déclaration et d'usage d'un périmètre d'erreur](https://codepen.io/gaearon/pen/wqvxGa?editors=0010) avec [React 16](/blog/2017/09/26/react-v16.0.html).
 
 
 ## Où placer les Error Boundaries ? {#where-to-place-error-boundaries}
 
-La granularité des périmètres d'erreurs est à votre discrétion. Vous pouvez envelopper les composants de routage haut-niveau pour afficher un message du type « Quelque chose s'est mal passé » à l'utilisateur, à l'image de ce qui est souvent fait par les frameworks côté serveur. Vous pouvez aussi envelopper chaque widget avec un périmètre d'erreur afin de les empêcher d'impacter le reste l'application.
+La granularité des périmètres d'erreurs est à votre discrétion. Vous pouvez envelopper les composants de routage haut-niveau pour afficher un message du type « Quelque chose s'est mal passé » à l'utilisateur, à l'image de ce qui est souvent fait par les frameworks côté serveur. Vous pouvez aussi envelopper chaque widget avec un périmètre d'erreur afin de les empêcher d'impacter le reste de l'application.
 
 
 ## Nouveau comportement pour les erreurs non attrapées {#new-behavior-for-uncaught-errors}
 
 Ce changement a un impact important. **À compter de React 16, les erreurs qui ne sont pas interceptées par un périmètre d'erreur entraîneront le démontage de l'intégralité de l'arbre des composants**.
 
-Cette décision a été débattue, mais selon notre expérience, laisser une interface corrompue en place est bien pire que de la supprimer complètement. Par exemple, dans un produit tel que Messenger, laisser une interface dégradée visible peut amener l'utilisateur à envoyer un message à la mauvaise personne. De la même façon, pour une application de paiement, afficher un mauvais montant est bien pire que de ne rien afficher du tout.
+Cette décision a été débattue, mais d'expérience nous avons remarqué qu'il est bien pire de laisser en place une interface corrompue que de la supprimer complètement. Par exemple, dans un produit tel que Messenger, laisser une interface dégradée visible peut amener l'utilisateur à envoyer un message à la mauvaise personne. De la même façon, pour une application de paiement, afficher un mauvais montant est bien pire que de ne rien afficher du tout.
 
 Cette modification signifie que lorsque vous migrez vers React 16, vous découvrirez probablement des plantages dans votre application qui étaient alors passés inaperçus. L'ajout de périmètres d'erreurs permet d'offrir une meilleure expérience utilisateurs en cas de problème.
 
 Par exemple, Facebook Messanger enveloppe le contenu de la barre latérale, du panneau d'information, du journal de conversation, ainsi que de la saisie du message dans des périmètres d'erreurs dinstincts. Si l'un des composants de ces zones d'interface fait défaut, les autres continueront de fonctionner normalement.
 
-Nous vous encourageons également à utiliser des services de rapport d'erreurs JavaScript (ou à construire le vôtre) afin de mieux connaître les exceptions non gérées dès qu'elles apparaissent en production, et ainsi de les corriger.
+Nous vous encourageons également à utiliser des services de rapport d'erreurs JavaScript (ou à construire le vôtre) afin de mieux connaître les exceptions non gérées dès qu'elles apparaissent en production, et donc de pouvoir les corriger.
 
 
 ## Trace d'appels des composants {#component-stack-traces}
@@ -92,7 +92,7 @@ React 16 affiche dans la console toutes les erreurs qui apparaissent durant le r
 
 <img src="../images/docs/error-boundaries-stack-trace.png" style="max-width:100%" alt="Une erreur interceptée par un périmètre d'erreur">
 
-Vous pouvez également voir les noms des fichiers et les lignes dans la trace d'appels du composant. C'est le fonctionnement par défaut dans les projets créés avec [Create React App](https://github.com/facebookincubator/create-react-app) :
+Vous pouvez également voir les noms des fichiers et les lignes dans la trace d'appels du composant. C'est le fonctionnement par défaut pour les projets créés avec [Create React App](https://github.com/facebookincubator/create-react-app) :
 
 <img src="../images/docs/error-boundaries-stack-trace-line-numbers.png" style="max-width:100%" alt="Une erreur interceptée par un périmètre d'erreur avec les numéros de lignes">
 
@@ -100,7 +100,7 @@ Si vous n'utilisez pas Create React App, vous pouvez ajouter [cette extension](h
 
 > Remarque :
 >
-> Les noms des composants affichés dans la trace d'appels dépendent de la propriété [`Function.name`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name). Si vous devez prendre en charge des navigateurs ou des dispositifs plus anciens qui ne proposent pas cela naturellement (par exemple IE 11), vous pourrez envisager d'inclure le polyfill [`function.name-polyfill`](https://github.com/JamesMGreene/Function.name) dans votre application. Vous pourrez également définir explicitement la propriété [`displayName`](/docs/react-component.html#displayname) sur tous vos composants.
+> Les noms des composants affichés dans la trace d'appels dépendent de la propriété [`Function.name`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name). Si vous devez prendre en charge des navigateurs ou des dispositifs plus anciens qui ne proposent pas ça nativement (par exemple IE 11), vous pourrez envisager d'inclure le polyfill [`function.name-polyfill`](https://github.com/JamesMGreene/Function.name) dans votre application. A titre d'alternative, vous pouvez également définir explicitement la propriété [`displayName`](/docs/react-component.html#displayname) sur tous vos composants.
 
 
 ## Et pourquoi pas try / catch ? {#how-about-trycatch}
@@ -121,13 +121,13 @@ Cependant, les composants React sont déclaratifs et spécifient *ce qui* doit �
 <Button />
 ```
 
-Les périmètres d'erreurs conservent la nature déclarative de React, et se comportent comme prévu. Par exemple, même si une erreur survient lors de la méthode `componentDidUpdate` causée par un `setState` quelque part dans l'arbre des composants, alors elle se propagera correctement à son périmètre d'erreur le plus proche.
+Les périmètres d'erreurs conservent la nature déclarative de React, et se comportent comme on s'y attend. Par exemple, même si une erreur survient lors de l'appel à la méthode `componentDidUpdate` causée par un `setState` quelque part dans l'arbre des composants, alors elle se propagera correctement vers son périmètre d'erreur le plus proche.
 
 ## Et à propos des gestionnaires d'événement ? {#how-about-event-handlers}
 
 Les périmètres d'erreurs n'interceptent **pas** les erreurs qui surviennent au sein des gestionnaires d'événements.
 
-React n'a pas besoin de périmètres d'erreurs pour récupérer des erreurs dans les gestionnaires d'événements. Contrairement aux méthodes de rendu ou du cycle de vie, les gestionnaires d'événements ne se produisent pas pendant le rendu. Ainsi, si cela arrive, React saura tout de même quoi afficher à l'écran.
+React n'a pas besoin de périmètres d'erreurs pour récupérer des erreurs dans les gestionnaires d'événements. Contrairement aux méthodes de rendu ou du cycle de vie, les gestionnaires d'événements ne sont pas appelés pendant le rendu. Ainsi, si cela arrive, React saura tout de même quoi afficher à l'écran.
 
 Si vous avez besoin d'intercepter une erreur au sein d'un gestionnaire d'événement, il suffit d'utiliser une instruction JavaScript classique `try` / `catch` :
 

--- a/content/docs/error-boundaries.md
+++ b/content/docs/error-boundaries.md
@@ -10,7 +10,7 @@ Auparavant, les erreurs JavaScript au sein des composants avaient l'habitude de 
 
 Une erreur JavaScript au sein de la partie UI ne devrait pas casser l'ensemble de l'application. Pour résoudre ce problème pour les utilisateurs de React, React 16 a introduit un nouveau concept appelé « *Error Boundary* » (nous utiliserons le terme de « Périmètre d'erreur » par la suite — NdT).
 
-Les périmètres d'erreurs sont des composants React qui **interceptent les erreurs JavaScript n'importe où au sein de leur arbre de composants enfants, trace ces erreurs, et affiche une interface de secours** à la place du composants en erreur. Les périmètres d'erreurs interceptent les erreurs durant le rendu, dans les méthodes du cycle de vie, ainsi que dans les constructeurs dans toute leur arborescence.
+Les périmètres d'erreurs sont des composants React qui **interceptent les erreurs JavaScript n'importe où au sein de leur arbre de composants enfants, enregistre ces erreurs, et affiche une interface de secours** à la place de l'arbre de composants en erreur. Les périmètres d'erreurs interceptent les erreurs durant le rendu, dans les méthodes du cycle de vie, ainsi que dans les constructeurs de tous les éléments de leur arborescence.
 
 > Remarque :
 >
@@ -21,7 +21,7 @@ Les périmètres d'erreurs sont des composants React qui **interceptent les erre
 > * Le code généré côté serveur.
 > * Les erreurs lancées dans le composant du périmètre d'erreur lui-même (plutôt qu'au sein de ses enfants).
 
-Une classe de composants devient un périmètre d'erreur s'il définit l'une (ou les deux) des méthodes du cycle de vie [`static getDerivedStateFromError()`](/docs/react-component.html#static-getderivedstatefromerror) ou [`componentDidCatch()`](/docs/react-component.html#componentdidcatch). Utilisez `static getDerivedStateFromError()` pour faire le rendu de l'UI de secours lorsqu'une erreur a été lancée. Utilisez `componentDidCatch()` pour tracer l'information relative à l'erreur.
+Une classe de composants devient un périmètre d'erreur s'il définit l'une (ou les deux) des méthodes du cycle de vie [`static getDerivedStateFromError()`](/docs/react-component.html#static-getderivedstatefromerror) ou [`componentDidCatch()`](/docs/react-component.html#componentdidcatch). Utilisez `static getDerivedStateFromError()` pour faire le rendu de l'UI de secours lorsqu'une erreur a été lancée. Utilisez `componentDidCatch()` pour enregistrer les informations relatives à l'erreur.
 
 ```js{7-10,12-15,18-21}
 class ErrorBoundary extends React.Component {
@@ -59,9 +59,9 @@ Vous pouvez alors l'utiliser comme un composant classique :
 </ErrorBoundary>
 ```
 
-Les périmètres d'erreurs fonctionnent comme un bloc JavaScript `catch {}`, mais pour des composants. Seules des classes de composants peuvent être des périmètres d'erreurs. En pratique, vous voudrez généralement définir un seul composant périmètre d'erreur et l'utiliser dans votre application.
+Les périmètres d'erreurs fonctionnent comme un bloc JavaScript `catch {}`, mais pour des composants. Seuls les composants à base de classe peuvent être des périmètres d'erreurs. En pratique, vous voudrez généralement définir un seul composant périmètre d'erreur pour l'utiliser partout dans votre application.
 
-Remarquez que **les périmètres d'erreurs ne détectent que les erreurs présentes en dessous d'eux dans l'arbre des composants**. Un périmètre d'erreur ne peut intercepter une erreur sur lui-même. Si un périmètre d'erreur échoue à faire le rendu du message d'erreur, l'erreur se propagera alors au périmètre d'erreur le plus proche. Cela est également similaire à la façon dont le bloc `catch {}` fonctionne en JavaScript.
+Remarquez que **les périmètres d'erreurs ne détectent que les erreurs présentes en dessous d'eux dans l'arbre des composants**. Un périmètre d'erreur ne peut intercepter une erreur sur lui-même. Si un périmètre d'erreur échoue à faire le rendu du message d'erreur, l'erreur se propagera alors au périmètre d'erreur suivant le plus proche. Là aussi, c'est similaire à la façon dont le bloc `catch {}` fonctionne en JavaScript.
 
 ## Démonstration {#live-demo}
 

--- a/content/docs/error-boundaries.md
+++ b/content/docs/error-boundaries.md
@@ -1,6 +1,6 @@
 ---
 id: error-boundaries
-title: Limiteur d'erreurs
+title: Limiteurs d'erreurs
 permalink: docs/error-boundaries.html
 ---
 

--- a/content/docs/error-boundaries.md
+++ b/content/docs/error-boundaries.md
@@ -8,20 +8,20 @@ Auparavant, les erreurs JavaScript au sein des composants avaient l'habitude de 
 
 ## L'arrivée des périmètres d'erreurs {#introducing-error-boundaries}
 
-Une erreur JavaScript au sein de la partie UI ne devrait pas casser l'ensemble de l'application. Pour résoudre ce problème pour les utilisateurs de React, React 16 a introduit un nouveau concept appelé « *Error Boundary* » (nous utiliserons le terme de « Périmètre d'erreur » par la suite — NdT).
+Une erreur JavaScript au sein d’une partie de l'interface utilisateur (UI) ne devrait pas casser l'ensemble de l'application. Pour résoudre ce problème pour les utilisateurs de React, React 16 a introduit un nouveau concept appelé « Périmètres d’erreurs » *(Error Boundaries, NdT)*.
 
-Les périmètres d'erreurs sont des composants React qui **interceptent les erreurs JavaScript n'importe où au sein de leur arbre de composants enfants, enregistre ces erreurs, et affiche une interface de secours** à la place de l'arbre de composants en erreur. Les périmètres d'erreurs interceptent les erreurs durant le rendu, dans les méthodes du cycle de vie, ainsi que dans les constructeurs de tous les éléments de leur arborescence.
+Les périmètres d'erreurs sont des composants React qui **interceptent les erreurs JavaScript n'importe où au sein de leur arbre de composants enfants, enregistrent ces erreurs, et affichent une UI de repli** à la place de l'arbre de composants qui a planté. Les périmètres d'erreurs interceptent les erreurs survenant au rendu, dans les méthodes de cycle de vie, ainsi que dans les constructeurs de tous les éléments de leur arborescence.
 
-> Remarque :
+> Remarque
 >
-> Les périmètres d'erreurs n'interceptent **pas** les erreurs pour :
+> Les périmètres d'erreurs n'interceptent **pas** les erreurs qui surviennent dans :
 >
-> * Les gestionnaire d'événements ([en savoir plus](#how-about-event-handlers)).
-> * Le code asynchrone (par exemple les fonctions de rappel `setTimeout` ou `requestAnimationFrame`).
-> * Le code généré côté serveur.
-> * Les erreurs lancées dans le composant du périmètre d'erreur lui-même (plutôt qu'au sein de ses enfants).
+> * Les gestionnaires d'événements ([en savoir plus](#how-about-event-handlers)).
+> * Le code asynchrone (par exemple les fonctions de rappel de `setTimeout` ou `requestAnimationFrame`).
+> * Le rendu côté serveur.
+> * Les erreurs levées dans le composant du périmètre d'erreur lui-même (plutôt qu'au sein de ses enfants).
 
-Une classe de composants devient un périmètre d'erreur s'il définit l'une (ou les deux) des méthodes du cycle de vie [`static getDerivedStateFromError()`](/docs/react-component.html#static-getderivedstatefromerror) ou [`componentDidCatch()`](/docs/react-component.html#componentdidcatch). Utilisez `static getDerivedStateFromError()` pour faire le rendu de l'UI de secours lorsqu'une erreur a été lancée. Utilisez `componentDidCatch()` pour enregistrer les informations relatives à l'erreur.
+Une classe de composant devient un périmètre d'erreur si elle définit au moins une des méthodes de cycle de vie [`static getDerivedStateFromError()`](/docs/react-component.html#static-getderivedstatefromerror) ou [`componentDidCatch()`](/docs/react-component.html#componentdidcatch). Utilisez `static getDerivedStateFromError()` pour afficher une UI de repli lorsqu'une erreur est levée. Utilisez `componentDidCatch()` pour enregistrer les informations relatives à l'erreur.
 
 ```js{7-10,12-15,18-21}
 class ErrorBoundary extends React.Component {
@@ -31,7 +31,7 @@ class ErrorBoundary extends React.Component {
   }
 
   static getDerivedStateFromError(error) {
-    // Mettez à jour l'état, de façon à montrer l'UI de secours au prochain rendu.
+    // Mettez à jour l'état, de façon à montrer l'UI de repli au prochain rendu.
     return { hasError: true };
   }
 
@@ -42,7 +42,7 @@ class ErrorBoundary extends React.Component {
 
   render() {
     if (this.state.hasError) {
-      // Vous pouvez faire le rendu de n'importe quelle UI de secours.
+      // Vous pouvez afficher n'importe quelle UI de repli.
       return <h1>Something went wrong.</h1>;
     }
 
@@ -59,53 +59,53 @@ Vous pouvez alors l'utiliser comme un composant classique :
 </ErrorBoundary>
 ```
 
-Les périmètres d'erreurs fonctionnent comme un bloc JavaScript `catch {}`, mais pour des composants. Seuls les composants à base de classe peuvent être des périmètres d'erreurs. En pratique, vous voudrez généralement définir un seul composant périmètre d'erreur pour l'utiliser partout dans votre application.
+Les périmètres d'erreurs fonctionnent comme un bloc JavaScript `catch {}`, mais pour les composants. Seuls les composants à base de classe peuvent être des périmètres d'erreurs. En pratique, vous voudrez généralement définir un seul composant de périmètre d'erreur puis l'utiliser partout dans votre application.
 
-Remarquez que **les périmètres d'erreurs ne détectent que les erreurs présentes en dessous d'eux dans l'arbre des composants**. Un périmètre d'erreur ne peut intercepter une erreur sur lui-même. Si un périmètre d'erreur échoue à faire le rendu du message d'erreur, l'erreur se propagera alors au périmètre d'erreur suivant le plus proche. Là aussi, c'est similaire à la façon dont le bloc `catch {}` fonctionne en JavaScript.
+Notez bien que **les périmètres d'erreurs ne détectent que les erreurs présentes en dessous d'eux dans l'arbre des composants**. Un périmètre d'erreur ne peut intercepter une erreur survenant dans son propre code. Si un périmètre d'erreur plante en tentant d'afficher son message d'erreur, l’erreur se propagera alors au périmètre d'erreur le plus proche au-dessus de lui dans l'arbre. Là aussi, c'est similaire à la façon dont le bloc `catch {}` fonctionne en JavaScript.
 
-## Démonstration {#live-demo}
+## Démonstration interactive {#live-demo}
 
-Jetez un coup d'œil sur [cet exemple de déclaration et d'usage d'un périmètre d'erreur](https://codepen.io/gaearon/pen/wqvxGa?editors=0010) avec [React 16](/blog/2017/09/26/react-v16.0.html).
-
-
-## Où placer les Error Boundaries ? {#where-to-place-error-boundaries}
-
-La granularité des périmètres d'erreurs est à votre discrétion. Vous pouvez envelopper les composants de routage haut-niveau pour afficher un message du type « Quelque chose s'est mal passé » à l'utilisateur, à l'image de ce qui est souvent fait par les frameworks côté serveur. Vous pouvez aussi envelopper chaque widget avec un périmètre d'erreur afin de les empêcher d'impacter le reste de l'application.
+Jetez un coup d'œil sur [cet exemple de déclaration et d'utilisation d'un périmètre d'erreur](https://codepen.io/gaearon/pen/wqvxGa?editors=0010) avec [React 16](/blog/2017/09/26/react-v16.0.html).
 
 
-## Nouveau comportement pour les erreurs non attrapées {#new-behavior-for-uncaught-errors}
+## Où placer les périmètres d'erreurs ? {#where-to-place-error-boundaries}
+
+La granularité des périmètres d'erreurs est à votre discrétion. Vous pourriez enrober les composants racines de routage pour afficher à l'utilisateur un message du type « Quelque chose s'est mal passé », à l'image de ce qui est souvent fait par les frameworks côté serveur. Vous pourriez aussi enrober des éléments d'interface précis avec un périmètre d'erreur afin de les empêcher de planter le reste de l'application.
+
+
+## Nouveau comportement pour les erreurs non-rattrapées {#new-behavior-for-uncaught-errors}
 
 Ce changement a un impact important. **À compter de React 16, les erreurs qui ne sont pas interceptées par un périmètre d'erreur entraîneront le démontage de l'intégralité de l'arbre des composants**.
 
 Cette décision a été débattue, mais d'expérience nous avons remarqué qu'il est bien pire de laisser en place une interface corrompue que de la supprimer complètement. Par exemple, dans un produit tel que Messenger, laisser une interface dégradée visible peut amener l'utilisateur à envoyer un message à la mauvaise personne. De la même façon, pour une application de paiement, afficher un mauvais montant est bien pire que de ne rien afficher du tout.
 
-Cette modification signifie que lorsque vous migrez vers React 16, vous découvrirez probablement des plantages dans votre application qui étaient alors passés inaperçus. L'ajout de périmètres d'erreurs permet d'offrir une meilleure expérience utilisateurs en cas de problème.
+Cette modification signifie que lorsque vous migrez vers React 16, vous découvrirez probablement des plantages dans votre application qui étaient jusque-là passés inaperçus. L'ajout de périmètres d'erreurs permet d'offrir une meilleure expérience utilisateur en cas de problème.
 
-Par exemple, Facebook Messanger enveloppe le contenu de la barre latérale, du panneau d'information, du journal de conversation, ainsi que de la saisie du message dans des périmètres d'erreurs dinstincts. Si l'un des composants de ces zones d'interface fait défaut, les autres continueront de fonctionner normalement.
+Par exemple, Facebook Messanger enrobe le contenu de la barre latérale, du panneau d'information, du journal de conversation, ainsi que de la saisie de message dans des périmètres d'erreurs distincts. Si l'un des composants de ces zones d'interface plante, les autres continueront de fonctionner normalement.
 
 Nous vous encourageons également à utiliser des services de rapport d'erreurs JavaScript (ou à construire le vôtre) afin de mieux connaître les exceptions non gérées dès qu'elles apparaissent en production, et donc de pouvoir les corriger.
 
 
-## Trace d'appels des composants {#component-stack-traces}
+## Traces de piles des composants {#component-stack-traces}
 
-React 16 affiche dans la console toutes les erreurs qui apparaissent durant le rendu en cours de développement, même si l'application les cachait accidentellement. En plus du message d'erreur et de la trace d'appels (*stacktrace*) JavaScript, il fournit également la trace d'appels du composant. Maintenant, vous pouvez voir exactement où l'erreur est apparue dans l'arbre des composants :
+En mode développement, React 16 affiche dans la console toutes les erreurs qui apparaissent durant le rendu, même si l'application les cache accidentellement. En plus du message d'erreur et de la trace de pile *(stack trace, NdT)* JavaScript, il fournit également la trace de pile du composant. Vous pouvez désormais voir exactement où l'erreur est apparue dans l'arbre des composants :
 
 <img src="../images/docs/error-boundaries-stack-trace.png" style="max-width:100%" alt="Une erreur interceptée par un périmètre d'erreur">
 
-Vous pouvez également voir les noms des fichiers et les lignes dans la trace d'appels du composant. C'est le fonctionnement par défaut pour les projets créés avec [Create React App](https://github.com/facebookincubator/create-react-app) :
+Vous pouvez également voir les noms des fichiers et les numéros de lignes dans la trace de pile du composant. C'est le fonctionnement par défaut pour les projets créés avec [Create React App](https://github.com/facebookincubator/create-react-app) :
 
 <img src="../images/docs/error-boundaries-stack-trace-line-numbers.png" style="max-width:100%" alt="Une erreur interceptée par un périmètre d'erreur avec les numéros de lignes">
 
-Si vous n'utilisez pas Create React App, vous pouvez ajouter [cette extension](https://www.npmjs.com/package/babel-plugin-transform-react-jsx-source) manuellement dans votre configuration Babel. Remarquez que cela ne doit être utilisé que durant le développement et **ne doit pas être activé en production**.
+Si vous n'utilisez pas Create React App, vous pouvez ajouter [cette extension](https://www.npmjs.com/package/babel-plugin-transform-react-jsx-source) manuellement dans votre configuration Babel. Remarquez que c'est conçu pour le développement et **ne doit pas être activé en production**.
 
-> Remarque :
+> Remarque
 >
-> Les noms des composants affichés dans la trace d'appels dépendent de la propriété [`Function.name`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name). Si vous devez prendre en charge des navigateurs ou des dispositifs plus anciens qui ne proposent pas ça nativement (par exemple IE 11), vous pourrez envisager d'inclure le polyfill [`function.name-polyfill`](https://github.com/JamesMGreene/Function.name) dans votre application. A titre d'alternative, vous pouvez également définir explicitement la propriété [`displayName`](/docs/react-component.html#displayname) sur tous vos composants.
+> Les noms des composants affichés dans la trace de pile dépendent de la propriété [`Function.name`](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Objets_globaux/Function/name). Si vous devez prendre en charge des navigateurs ou des dispositifs plus anciens qui ne proposent pas ça nativement (par exemple IE 11), vous pouvez envisager d'inclure le polyfill [`function.name-polyfill`](https://github.com/JamesMGreene/Function.name) dans votre application. Autrement, vous pouvez également définir explicitement la propriété [`displayName`](/docs/react-component.html#displayname) sur tous vos composants.
 
 
 ## Et pourquoi pas try / catch ? {#how-about-trycatch}
 
-Les instructions `try` / `catch` sont vraiment intéressantes, mais ne marchent qu'avec du code impératif :
+Les `try` / `catch` sont super, mais ne marchent qu'avec du code impératif :
 
 ```js
 try {
@@ -115,21 +115,21 @@ try {
 }
 ```
 
-Cependant, les composants React sont déclaratifs et spécifient *ce qui* doit être rendu :
+Mais les composants React sont déclaratifs et spécifient *ce qui* doit être rendu :
 
 ```js
 <Button />
 ```
 
-Les périmètres d'erreurs conservent la nature déclarative de React, et se comportent comme on s'y attend. Par exemple, même si une erreur survient lors de l'appel à la méthode `componentDidUpdate` causée par un `setState` quelque part dans l'arbre des composants, alors elle se propagera correctement vers son périmètre d'erreur le plus proche.
+Les périmètres d'erreurs respectent la nature déclarative de React, et se comportent sans surprises. Par exemple, même si une erreur survient dans une méthode `componentDidUpdate` suite à un `setState` quelque part au fin fond de l'arbre des composants, elle se propagera correctement jusqu’au périmètre d'erreur le plus proche.
 
-## Et à propos des gestionnaires d'événement ? {#how-about-event-handlers}
+## Et les gestionnaires d'événements ? {#how-about-event-handlers}
 
 Les périmètres d'erreurs n'interceptent **pas** les erreurs qui surviennent au sein des gestionnaires d'événements.
 
-React n'a pas besoin de périmètres d'erreurs pour récupérer des erreurs dans les gestionnaires d'événements. Contrairement aux méthodes de rendu ou du cycle de vie, les gestionnaires d'événements ne sont pas appelés pendant le rendu. Ainsi, si cela arrive, React saura tout de même quoi afficher à l'écran.
+React n'a pas besoin de périmètres d'erreurs pour gérer les erreurs dans les gestionnaires d'événements. Contrairement aux méthodes de rendu ou de cycle de vie, les gestionnaires d'événements ne sont pas appelés pendant le rendu. Du coup même si ces gestionnaires lèvent une erreur, React saura tout de même quoi afficher à l'écran.
 
-Si vous avez besoin d'intercepter une erreur au sein d'un gestionnaire d'événement, il suffit d'utiliser une instruction JavaScript classique `try` / `catch` :
+Si vous avez besoin d'intercepter une erreur au sein d'un gestionnaire d'événements, il suffit d'utiliser un classique `try` / `catch` JavaScript :
 
 ```js{9-13,17-20}
 class MyComponent extends React.Component {
@@ -141,7 +141,7 @@ class MyComponent extends React.Component {
 
   handleClick() {
     try {
-      // Faites ici quelque chose qui va émettre une erreur.
+      // Faites ici quelque chose qui va lever une erreur
     } catch (error) {
       this.setState({ error });
     }
@@ -151,15 +151,15 @@ class MyComponent extends React.Component {
     if (this.state.error) {
       return <h1>Une erreur a été interceptée.</h1>
     }
-    return <div onClick={this.handleClick}>Cliquez-moi</div>
+    return <div onClick={this.handleClick}>Cliquez ici</div>
   }
 }
 ```
 
 Remarquez que l'exemple ci-dessus illustre un comportement JavaScript classique et n'utilise aucun périmètre d'erreur.
 
-## Changement de nommage depuis React 15 {#naming-changes-from-react-15}
+## Changements de nommage par rapport à React 15 {#naming-changes-from-react-15}
 
-React 15 disposait d'une prise en charge très limitée des périmètres d'erreurs sous un nom de méthode différent : `unstable_handleError`. Cette méthode ne fonctionne plus, et vous devrez la remplacer par `componentDidCatch` dans votre code à partir de la première version bêta 16 de React.
+React 15 disposait d'une prise en charge très limitée des périmètres d'erreurs sous un nom de méthode différent : `unstable_handleError`. Cette méthode ne fonctionne plus, et vous devrez la remplacer par `componentDidCatch` dans votre code à partir de la première version bêta de React 16.
 
 Pour ce changement, nous fournissons un [codemod](https://github.com/reactjs/react-codemod#error-boundaries) pour migrer automatiquement votre code.

--- a/content/docs/error-boundaries.md
+++ b/content/docs/error-boundaries.md
@@ -100,7 +100,7 @@ Si vous n'utilisez pas Create React App, vous pouvez ajouter [cette extension](h
 
 > Remarque :
 >
-> Les noms des composants affichés dans la trace d'appels dépendent de la propriété [`Function.name`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name). Si vous devez prendre en charge des navigateurs ou des dispositifs plus anciens qui ne proposent pas cela naturellement (par exemple IE 11), vous pourrez envisager d'inclure le polyfill [`Function.name`](https://github.com/JamesMGreene/Function.name) dans votre application. Vous pourrez également définir explicitement la propriété [`displayName`](/docs/react-component.html#displayname) sur tous vos composants.
+> Les noms des composants affichés dans la trace d'appels dépendent de la propriété [`Function.name`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name). Si vous devez prendre en charge des navigateurs ou des dispositifs plus anciens qui ne proposent pas cela naturellement (par exemple IE 11), vous pourrez envisager d'inclure le polyfill [`function.name-polyfill`](https://github.com/JamesMGreene/Function.name) dans votre application. Vous pourrez également définir explicitement la propriété [`displayName`](/docs/react-component.html#displayname) sur tous vos composants.
 
 
 ## Et pourquoi pas try / catch ? {#how-about-trycatch}

--- a/content/docs/error-boundaries.md
+++ b/content/docs/error-boundaries.md
@@ -1,27 +1,27 @@
 ---
 id: error-boundaries
-title: Limiteurs d'erreurs
+title: Périmètres d'erreurs
 permalink: docs/error-boundaries.html
 ---
 
 Auparavant, les erreurs JavaScript au sein des composants avaient l'habitude de corrompre l'état interne de React, et de causer des [erreurs](https://github.com/facebook/react/issues/4026) [assez](https://github.com/facebook/react/issues/6895) [incompréhensibles](https://github.com/facebook/react/issues/8579) lors des rendus suivants. Ces erreurs étaient toujours causées par une erreur antérieure dans le code applicatif, et React ne proposait alors aucun moyen de les gérer correctement dans les composants, et n'était pas capable de se rétablir.
 
-## L'arrivée des limiteurs d'erreurs {#introducing-error-boundaries}
+## L'arrivée des périmètres d'erreurs {#introducing-error-boundaries}
 
-Une erreur JavaScript au sein de la partie UI ne devrait pas casser l'ensemble de l'application. Pour résoudre ce problème pour les utilisateurs de React, React 16 a introduit un nouveau concept appelé « *Error Boundary* » (nous traduirons ce terme par « Limiteur d'erreur » par la suite — NdT).
+Une erreur JavaScript au sein de la partie UI ne devrait pas casser l'ensemble de l'application. Pour résoudre ce problème pour les utilisateurs de React, React 16 a introduit un nouveau concept appelé « *Error Boundary* » (nous utiliserons le terme de « Périmètre d'erreur » par la suite — NdT).
 
-Les limiteurs d'erreurs sont des composants React qui **interceptent les erreurs JavaScript n'importe où au sein de leur arbre de composants enfants, trace ces erreurs, et affiche une interface de secours** à la place du composants en erreur. Les limiteurs d'erreurs interceptent les erreurs durant le rendu, dans les méthodes du cycle de vie, ainsi que dans les constructeurs dans toute leur arborescence.
+Les périmètres d'erreurs sont des composants React qui **interceptent les erreurs JavaScript n'importe où au sein de leur arbre de composants enfants, trace ces erreurs, et affiche une interface de secours** à la place du composants en erreur. Les périmètres d'erreurs interceptent les erreurs durant le rendu, dans les méthodes du cycle de vie, ainsi que dans les constructeurs dans toute leur arborescence.
 
 > Remarque :
 >
-> Les limiteurs d'erreurs n'interceptent **pas** les erreurs pour :
+> Les périmètres d'erreurs n'interceptent **pas** les erreurs pour :
 >
 > * Les gestionnaire d'événements ([en savoir plus](#how-about-event-handlers)).
 > * Le code asynchrone (par exemple les fonctions de rappel `setTimeout` ou `requestAnimationFrame`).
 > * Le code généré côté serveur.
-> * Les erreurs lancées dans le composant du limiteur d'erreur lui-même (plutôt qu'au sein de ses enfants).
+> * Les erreurs lancées dans le composant du périmètre d'erreur lui-même (plutôt qu'au sein de ses enfants).
 
-Une classe de composants devient un limiteur d'erreur s'il définit l'une (ou les deux) des méthodes du cycle de vie [`static getDerivedStateFromError()`](/docs/react-component.html#static-getderivedstatefromerror) ou [`componentDidCatch()`](/docs/react-component.html#componentdidcatch). Utilisez `static getDerivedStateFromError()` pour faire le rendu de l'UI de secours lorsqu'une erreur a été lancée. Utilisez `componentDidCatch()` pour tracer l'information relative à l'erreur.
+Une classe de composants devient un périmètre d'erreur s'il définit l'une (ou les deux) des méthodes du cycle de vie [`static getDerivedStateFromError()`](/docs/react-component.html#static-getderivedstatefromerror) ou [`componentDidCatch()`](/docs/react-component.html#componentdidcatch). Utilisez `static getDerivedStateFromError()` pour faire le rendu de l'UI de secours lorsqu'une erreur a été lancée. Utilisez `componentDidCatch()` pour tracer l'information relative à l'erreur.
 
 ```js{7-10,12-15,18-21}
 class ErrorBoundary extends React.Component {
@@ -59,29 +59,29 @@ Vous pouvez alors l'utiliser comme un composant classique :
 </ErrorBoundary>
 ```
 
-Les limiteurs d'erreurs fonctionnent comme un bloc JavaScript `catch {}`, mais pour des composants. Seules des classes de composants peuvent être des limiteurs d'erreurs. En pratique, vous voudrez généralement définir un seul composant limiteur d'erreur et l'utiliser dans votre application.
+Les périmètres d'erreurs fonctionnent comme un bloc JavaScript `catch {}`, mais pour des composants. Seules des classes de composants peuvent être des périmètres d'erreurs. En pratique, vous voudrez généralement définir un seul composant périmètre d'erreur et l'utiliser dans votre application.
 
-Remarquez que **les limiteurs d'erreurs ne détectent que les erreurs présentes en dessous d'eux dans l'arbre des composants**. Un limiteurs d'erreur ne peut intercepter une erreur sur lui-même. Si un limiteur d'erreur échoue à faire le rendu du message d'erreur, l'erreur se propagera alors au limiteur d'erreur le plus proche. Cela est également similaire à la façon dont le bloc `catch {}` fonctionne en JavaScript.
+Remarquez que **les périmètres d'erreurs ne détectent que les erreurs présentes en dessous d'eux dans l'arbre des composants**. Un périmètre d'erreur ne peut intercepter une erreur sur lui-même. Si un périmètre d'erreur échoue à faire le rendu du message d'erreur, l'erreur se propagera alors au périmètre d'erreur le plus proche. Cela est également similaire à la façon dont le bloc `catch {}` fonctionne en JavaScript.
 
 ## Démonstration {#live-demo}
 
-Jetez un œil sur [cet exemple de déclaration et d'usage d'un limiteur d'erreur](https://codepen.io/gaearon/pen/wqvxGa?editors=0010) avec [React 16](/blog/2017/09/26/react-v16.0.html).
+Jetez un œil sur [cet exemple de déclaration et d'usage d'un périmètre d'erreur](https://codepen.io/gaearon/pen/wqvxGa?editors=0010) avec [React 16](/blog/2017/09/26/react-v16.0.html).
 
 
 ## Où placer les Error Boundaries ? {#where-to-place-error-boundaries}
 
-La granularité des limiteurs d'erreurs est à votre discrétion. Vous pouvez envelopper les composants de routage haut-niveau pour afficher un message du type « Quelque chose s'est mal passé » à l'utilisateur, à l'image de ce qui est souvent fait par les frameworks côté serveur. Vous pouvez aussi envelopper chaque widget avec un limiteur d'erreur afin de les empêcher d'impacter le reste l'application.
+La granularité des périmètres d'erreurs est à votre discrétion. Vous pouvez envelopper les composants de routage haut-niveau pour afficher un message du type « Quelque chose s'est mal passé » à l'utilisateur, à l'image de ce qui est souvent fait par les frameworks côté serveur. Vous pouvez aussi envelopper chaque widget avec un périmètre d'erreur afin de les empêcher d'impacter le reste l'application.
 
 
 ## Nouveau comportement pour les erreurs non attrapées {#new-behavior-for-uncaught-errors}
 
-Ce changement a un impact important. **À compter de React 16, les erreurs qui ne sont pas interceptées par un limiteur d'erreur entraîneront le démontage de l'intégralité de l'arbre des composants**.
+Ce changement a un impact important. **À compter de React 16, les erreurs qui ne sont pas interceptées par un périmètre d'erreur entraîneront le démontage de l'intégralité de l'arbre des composants**.
 
 Cette décision a été débattue, mais selon notre expérience, laisser une interface corrompue en place est bien pire que de la supprimer complètement. Par exemple, dans un produit tel que Messenger, laisser une interface dégradée visible peut amener l'utilisateur à envoyer un message à la mauvaise personne. De la même façon, pour une application de paiement, afficher un mauvais montant est bien pire que de ne rien afficher du tout.
 
-Cette modification signifie que lorsque vous migrez vers React 16, vous découvrirez probablement des plantages dans votre application qui étaient alors passés inaperçus. L'ajout de limiteurs d'erreurs permet d'offrir une meilleure expérience utilisateurs en cas de problème.
+Cette modification signifie que lorsque vous migrez vers React 16, vous découvrirez probablement des plantages dans votre application qui étaient alors passés inaperçus. L'ajout de périmètres d'erreurs permet d'offrir une meilleure expérience utilisateurs en cas de problème.
 
-Par exemple, Facebook Messanger enveloppe le contenu de la barre latérale, du panneau d'information, du journal de conversation, ainsi que de la saisie du message dans des limiteurs d'erreurs dinstincts. Si l'un des composants de ces zones d'interface fait défaut, les autres continueront de fonctionner normalement.
+Par exemple, Facebook Messanger enveloppe le contenu de la barre latérale, du panneau d'information, du journal de conversation, ainsi que de la saisie du message dans des périmètres d'erreurs dinstincts. Si l'un des composants de ces zones d'interface fait défaut, les autres continueront de fonctionner normalement.
 
 Nous vous encourageons également à utiliser des services de rapport d'erreurs JavaScript (ou à construire le vôtre) afin de mieux connaître les exceptions non gérées dès qu'elles apparaissent en production, et ainsi de les corriger.
 
@@ -90,11 +90,11 @@ Nous vous encourageons également à utiliser des services de rapport d'erreurs 
 
 React 16 affiche dans la console toutes les erreurs qui apparaissent durant le rendu en cours de développement, même si l'application les cachait accidentellement. En plus du message d'erreur et de la trace d'appels (*stacktrace*) JavaScript, il fournit également la trace d'appels du composant. Maintenant, vous pouvez voir exactement où l'erreur est apparue dans l'arbre des composants :
 
-<img src="../images/docs/error-boundaries-stack-trace.png" style="max-width:100%" alt="Une erreur interceptée par un limiteur d'erreur">
+<img src="../images/docs/error-boundaries-stack-trace.png" style="max-width:100%" alt="Une erreur interceptée par un périmètre d'erreur">
 
 Vous pouvez également voir les noms des fichiers et les lignes dans la trace d'appels du composant. C'est le fonctionnement par défaut dans les projets créés avec [Create React App](https://github.com/facebookincubator/create-react-app) :
 
-<img src="../images/docs/error-boundaries-stack-trace-line-numbers.png" style="max-width:100%" alt="Une erreur interceptée par un limiteur d'erreur avec les numéros de lignes">
+<img src="../images/docs/error-boundaries-stack-trace-line-numbers.png" style="max-width:100%" alt="Une erreur interceptée par un périmètre d'erreur avec les numéros de lignes">
 
 Si vous n'utilisez pas Create React App, vous pouvez ajouter [cette extension](https://www.npmjs.com/package/babel-plugin-transform-react-jsx-source) manuellement dans votre configuration Babel. Remarquez que cela ne doit être utilisé que durant le développement et **ne doit pas être activé en production**.
 
@@ -121,13 +121,13 @@ Cependant, les composants React sont déclaratifs et spécifient *ce qui* doit �
 <Button />
 ```
 
-Les limiteurs d'erreurs conservent la nature déclarative de React, et se comportent comme prévu. Par exemple, même si une erreur survient lors de la méthode `componentDidUpdate` causée par un `setState` quelque part dans l'arbre des composants, alors elle se propagera correctement à son limiteur d'erreur le plus proche.
+Les périmètres d'erreurs conservent la nature déclarative de React, et se comportent comme prévu. Par exemple, même si une erreur survient lors de la méthode `componentDidUpdate` causée par un `setState` quelque part dans l'arbre des composants, alors elle se propagera correctement à son périmètre d'erreur le plus proche.
 
 ## Et à propos des gestionnaires d'événement ? {#how-about-event-handlers}
 
-Les limiteurs d'erreurs n'interceptent **pas** les erreurs qui surviennent au sein des gestionnaires d'événements.
+Les périmètres d'erreurs n'interceptent **pas** les erreurs qui surviennent au sein des gestionnaires d'événements.
 
-React n'a pas besoin de limiteurs d'erreurs pour récupérer des erreurs dans les gestionnaires d'événements. Contrairement aux méthodes de rendu ou du cycle de vie, les gestionnaires d'événements ne se produisent pas pendant le rendu. Ainsi, si cela arrive, React saura tout de même quoi afficher à l'écran.
+React n'a pas besoin de périmètres d'erreurs pour récupérer des erreurs dans les gestionnaires d'événements. Contrairement aux méthodes de rendu ou du cycle de vie, les gestionnaires d'événements ne se produisent pas pendant le rendu. Ainsi, si cela arrive, React saura tout de même quoi afficher à l'écran.
 
 Si vous avez besoin d'intercepter une erreur au sein d'un gestionnaire d'événement, il suffit d'utiliser une instruction JavaScript classique `try` / `catch` :
 
@@ -156,10 +156,10 @@ class MyComponent extends React.Component {
 }
 ```
 
-Remarquez que l'exemple ci-dessus illustre un comportement JavaScript classique et n'utilise aucun limiteur d'erreur.
+Remarquez que l'exemple ci-dessus illustre un comportement JavaScript classique et n'utilise aucun périmètre d'erreur.
 
 ## Changement de nommage depuis React 15 {#naming-changes-from-react-15}
 
-React 15 disposait d'une prise en charge très limitée de limiteurs d'erreurs sous un nom de méthode différent : `unstable_handleError`. Cette méthode ne fonctionne plus, et vous devrez la remplacer par `componentDidCatch` dans votre code à partir de la première version bêta 16 de React.
+React 15 disposait d'une prise en charge très limitée des périmètres d'erreurs sous un nom de méthode différent : `unstable_handleError`. Cette méthode ne fonctionne plus, et vous devrez la remplacer par `componentDidCatch` dans votre code à partir de la première version bêta 16 de React.
 
 Pour ce changement, nous fournissons un [codemod](https://github.com/reactjs/react-codemod#error-boundaries) pour migrer automatiquement votre code.


### PR DESCRIPTION
Bonjour,

Voici ma proposition de traduction pour la page [Error Boundaries](https://reactjs.org/docs/error-boundaries.html).

La traduction de `Error boundaries` n'est effectivement [pas simple](https://github.com/reactjs/fr.reactjs.org/pull/55#issuecomment-465330724), j'ai mis `Limiteur d'erreur` mais je ne suis pas vraiment satisfait.
Soit on trouve mieux, soit on laisse, soit on garde le terme anglais (en mettant une petite note de traduction au début).

/poke @tdd :)
