### PR TITLE
Translation - Don't call proptypes

### DIFF
--- a/content/warnings/dont-call-proptypes.md
+++ b/content/warnings/dont-call-proptypes.md
@@ -8,9 +8,9 @@ permalink: warnings/dont-call-proptypes.html
 >
 > `React.PropTypes` a été déplacé dans un paquet différent depuis React v15.5. Merci d'utiliser [la bibliothèque `prop-types` à la place](https://www.npmjs.com/package/prop-types).
 >
->Nous fournissons [un scripte codemod](/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes) pour automatiser la conversion.
+>Nous fournissons [un script codemod](/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes) pour automatiser la conversion.
 
-Dans une future version majeure de React, le code implémentant les fonctions de validation PropType sera supprimé en production. Une fois que cela se produit, tout code appelant ces fonctions manuellement (qui n'est pas supprimé en production) génèrera une erreur.
+Dans une future version majeure de React, le code implémentant les fonctions de validation PropType sera supprimé en production. Une fois que cela se produit, tout code appelant ces fonctions manuellement (qui n'est pas supprimé en production) générera une erreur.
 
 ### Déclarer des PropTypes est toujours correct {#declaring-proptypes-is-still-fine}
 
@@ -22,11 +22,11 @@ Button.propTypes = {
 };
 ```
 
-Rien ne channge ici.
+Rien ne change ici.
 
 ### N'appelez pas PropTypes directement {#dont-call-proptypes-directly}
 
-L'utilisation de PropTypes autrement que par l'annotation de composants React avec eux n'est plus soutenu :
+L'utilisation de PropTypes autrement que par l'annotation de composants React n'est plus soutenu :
 
 ```javascript
 var apiShape = PropTypes.shape({
@@ -55,7 +55,7 @@ Button.propTypes = {
 }
 ```
 
-Dans ce cas, `ThirdPartyPropTypes.deprecated` est un container appelant` PropTypes.bool`. Ce modèle en soi est correct, mais déclenche un faux positif car React pense que vous appelez directement PropTypes. La section suivante explique comment résoudre ce problème pour une bibliothèque implémentant quelque chose similaire à `ThirdPartyPropTypes`. Si ce n'est pas une bibliothèque que vous avez écrite, vous pouvez créer un problème à ce sujet.
+Dans ce cas, `ThirdPartyPropTypes.deprecated` est un container appelant `PropTypes.bool`. Ce modèle en soi est correct, mais déclenche un faux positif, car React pense que vous appelez directement PropTypes. La section suivante explique comment résoudre ce problème pour une bibliothèque implémentant quelque chose similaire à `ThirdPartyPropTypes`. Si ce n'est pas une bibliothèque que vous avez écrite, vous pouvez créer un problème à ce sujet.
 
 ### Correction du faux positif dans les PropTypes tiers {#fixing-the-false-positive-in-third-party-proptypes}
 
@@ -83,7 +83,7 @@ Afin de corriger le faux positif, assurez-vous de transmettre **tous** les argum
 
 ```javascript
 export default function deprecated(propType, explanation) {
-  return function validate(props, propName, componentName, ...rest) { // Note ...rest here
+  return function validate(props, propName, componentName, ...rest) { // Notez ...rest ici
     if (props[propName] != null) {
       const message = `"${propName}" property of "${componentName}" has been deprecated.\n${explanation}`;
       if (!warned[message]) {
@@ -92,7 +92,7 @@ export default function deprecated(propType, explanation) {
       }
     }
 
-    return propType(props, propName, componentName, ...rest); // and here
+    return propType(props, propName, componentName, ...rest); // et ici
   };
 }
 ```

--- a/content/warnings/dont-call-proptypes.md
+++ b/content/warnings/dont-call-proptypes.md
@@ -81,7 +81,7 @@ export default function deprecated(propType, explanation) {
 }
 ```
 
-Afin de corriger le faux positif, assurez-vous de transmettre **tous** les arguments au PropType encapsulé. Chose facile à faire avec la notation ES6 `... rest`:
+Afin de corriger le faux positif, assurez-vous de transmettre **tous** les arguments au PropType enrobé. C’est facile à faire avec la notation ES6 `...rest` :
 
 ```javascript
 export default function deprecated(propType, explanation) {

--- a/content/warnings/dont-call-proptypes.md
+++ b/content/warnings/dont-call-proptypes.md
@@ -4,7 +4,9 @@ layout: single
 permalink: warnings/dont-call-proptypes.html
 ---
 
-> Note :
+N’appelez pas les PropTypes
+
+> Remarque
 >
 > `React.PropTypes` a été déplacé dans un paquet différent depuis React v15.5. Merci d'utiliser [la bibliothèque `prop-types` à la place](https://www.npmjs.com/package/prop-types).
 >

--- a/content/warnings/dont-call-proptypes.md
+++ b/content/warnings/dont-call-proptypes.md
@@ -63,7 +63,7 @@ Dans ce cas, `ThirdPartyPropTypes.deprecated` est un container appelant `PropTyp
 
 Si vous êtes l'auteur·e d'une bibliothèque PropTypes tierce et que vous laissez vos utilisateurs enrober les PropTypes React existants, ils risquent de voir apparaître cet avertissement provenant de votre bibliothèque. C’est dû au fait que React ne voit pas le dernier argument « secret » qu'il [passe](https://github.com/facebook/react/pull/7132) pour détecter les appels manuels à PropTypes.
 
-Voici comment y remédier. Nous utiliserons `deprecated` à partir de  [react-bootstrap/react-prop-types](https://github.com/react-bootstrap/react-prop-types/blob/0d1cd3a49a93e513325e3258b28a82ce7d38e690/src/deprecated.js) comme exemple. L'implémentation actuelle ne transmet que les arguments `props`, `propName`, et `componentName` :
+Voici comment y remédier. Nous utiliserons le `deprecated` de  [react-bootstrap/react-prop-types](https://github.com/react-bootstrap/react-prop-types/blob/0d1cd3a49a93e513325e3258b28a82ce7d38e690/src/deprecated.js) comme exemple. L'implémentation actuelle ne transmet que les arguments `props`, `propName`, et `componentName` :
 
 ```javascript
 export default function deprecated(propType, explanation) {

--- a/content/warnings/dont-call-proptypes.md
+++ b/content/warnings/dont-call-proptypes.md
@@ -40,7 +40,7 @@ var apiShape = PropTypes.shape({
 var error = apiShape(json, 'response');
 ```
 
-Si vous comptez utiliser de tels PropTypes, nous vous encourageons à utiliser ou créer un fork de PropTypes (tels que [ces](https://github.com/aackerman/PropTypes) [deux](https://github.com/developit/proptypes) paquets).
+Si vous avez besoin d’utiliser PropTypes de cette façon, nous vous encourageons à utiliser ou créer un *fork* de PropTypes (tels que [ces](https://github.com/aackerman/PropTypes) [deux](https://github.com/developit/proptypes) modules).
 
 Si vous ne corrigez pas l'avertissement, ce code plantera en production avec React 16.
 

--- a/content/warnings/dont-call-proptypes.md
+++ b/content/warnings/dont-call-proptypes.md
@@ -12,7 +12,7 @@ N’appelez pas les PropTypes
 >
 >Nous fournissons [un script codemod](/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes) pour automatiser la conversion.
 
-Dans une future version majeure de React, le code implémentant les fonctions de validation PropType sera supprimé en production. Une fois que cela se produit, tout code appelant ces fonctions manuellement (qui n'est pas supprimé en production) générera une erreur.
+Dans une future version majeure de React, le code implémentant les fonctions de validation de PropType sera supprimé en production. Quand ça arrivera, tout code appelant ces fonctions manuellement (si ce code n'est pas supprimé en production) lèvera une erreur.
 
 ### Déclarer des PropTypes reste une bonne idée {#declaring-proptypes-is-still-fine}
 

--- a/content/warnings/dont-call-proptypes.md
+++ b/content/warnings/dont-call-proptypes.md
@@ -85,7 +85,7 @@ Afin de corriger le faux positif, assurez-vous de transmettre **tous** les argum
 
 ```javascript
 export default function deprecated(propType, explanation) {
-  return function validate(props, propName, componentName, ...rest) { // Notez ...rest ici
+  return function validate(props, propName, componentName, ...rest) { // Remarquez le ...rest ici
     if (props[propName] != null) {
       const message = `"${propName}" property of "${componentName}" has been deprecated.\n${explanation}`;
       if (!warned[message]) {

--- a/content/warnings/dont-call-proptypes.md
+++ b/content/warnings/dont-call-proptypes.md
@@ -36,7 +36,7 @@ var apiShape = PropTypes.shape({
   statusCode: PropTypes.number.isRequired
 }).isRequired;
 
-// N'est plus soutenu !
+// N'est plus accepté !
 var error = apiShape(json, 'response');
 ```
 

--- a/content/warnings/dont-call-proptypes.md
+++ b/content/warnings/dont-call-proptypes.md
@@ -46,7 +46,7 @@ Si vous ne corrigez pas l'avertissement, ce code plantera en production avec Rea
 
 ### Si vous n'appelez pas directement PropTypes mais recevez toujours l'avertissement {#if-you-dont-call-proptypes-directly-but-still-get-the-warning}
 
-Inspectez la trace de pile générée par l'avertissement. Vous trouverez la définition de composant responsable de l'appel direct PropTypes. Le problème est probablement dû à des PropTypes tiers qui enveloppent les PropTypes de React, par exemple :
+Inspectez la pile d’appels générée par l'avertissement. Vous y trouverez la définition de composant responsable de l'appel direct à PropTypes. Le problème est probablement dû à des PropTypes tiers qui enrobent ceux de React, par exemple :
 
 ```js
 Button.propTypes = {

--- a/content/warnings/dont-call-proptypes.md
+++ b/content/warnings/dont-call-proptypes.md
@@ -14,7 +14,7 @@ N’appelez pas les PropTypes
 
 Dans une future version majeure de React, le code implémentant les fonctions de validation PropType sera supprimé en production. Une fois que cela se produit, tout code appelant ces fonctions manuellement (qui n'est pas supprimé en production) générera une erreur.
 
-### Déclarer des PropTypes est toujours correct {#declaring-proptypes-is-still-fine}
+### Déclarer des PropTypes reste une bonne idée {#declaring-proptypes-is-still-fine}
 
 L'utilisation normale de PropTypes est toujours prise en charge :
 

--- a/content/warnings/dont-call-proptypes.md
+++ b/content/warnings/dont-call-proptypes.md
@@ -57,7 +57,7 @@ Button.propTypes = {
 }
 ```
 
-Dans ce cas, `ThirdPartyPropTypes.deprecated` est un container appelant `PropTypes.bool`. Ce modèle en soi est correct, mais déclenche un faux positif, car React pense que vous appelez directement PropTypes. La section suivante explique comment résoudre ce problème pour une bibliothèque implémentant quelque chose similaire à `ThirdPartyPropTypes`. Si ce n'est pas une bibliothèque que vous avez écrite, vous pouvez créer un problème à ce sujet.
+Dans ce cas, `ThirdPartyPropTypes.deprecated` est un enrobage qui appelle `PropTypes.bool`. Ce modèle n’a rien de mauvais en soi, mais il déclenche un faux positif car React pense que vous appelez directement PropTypes. La section suivante explique comment résoudre ce problème pour une bibliothèque implémentant quelque chose de similaire à `ThirdPartyPropTypes`. Si ce n'est pas une bibliothèque que vous avez écrite, vous pouvez déposer une *issue* sur son dépôt public.
 
 ### Correction du faux positif dans les PropTypes tiers {#fixing-the-false-positive-in-third-party-proptypes}
 

--- a/content/warnings/dont-call-proptypes.md
+++ b/content/warnings/dont-call-proptypes.md
@@ -1,5 +1,5 @@
 ---
-title: Avertissement Don't Call PropTypes
+title: "Avertissement : don't call PropTypes"
 layout: single
 permalink: warnings/dont-call-proptypes.html
 ---

--- a/content/warnings/dont-call-proptypes.md
+++ b/content/warnings/dont-call-proptypes.md
@@ -16,7 +16,7 @@ Dans une future version majeure de React, le code implémentant les fonctions de
 
 ### Déclarer des PropTypes reste une bonne idée {#declaring-proptypes-is-still-fine}
 
-L'utilisation normale de PropTypes est toujours prise en charge :
+L'utilisation normale de PropTypes reste prise en charge :
 
 ```javascript
 Button.propTypes = {

--- a/content/warnings/dont-call-proptypes.md
+++ b/content/warnings/dont-call-proptypes.md
@@ -28,7 +28,7 @@ Rien ne change ici.
 
 ### N'appelez pas PropTypes directement {#dont-call-proptypes-directly}
 
-L'utilisation de PropTypes autrement que par l'annotation de composants React n'est plus soutenu :
+L'utilisation de PropTypes autrement que par l'annotation de composants React n'est plus acceptée :
 
 ```javascript
 var apiShape = PropTypes.shape({

--- a/content/warnings/dont-call-proptypes.md
+++ b/content/warnings/dont-call-proptypes.md
@@ -1,20 +1,20 @@
 ---
-title: Don't Call PropTypes Warning
+title: Avertissement Don't Call PropTypes
 layout: single
 permalink: warnings/dont-call-proptypes.html
 ---
 
-> Note:
+> Note :
 >
-> `React.PropTypes` has moved into a different package since React v15.5. Please use [the `prop-types` library instead](https://www.npmjs.com/package/prop-types).
+> `React.PropTypes` a été déplacé dans un paquet différent depuis React v15.5. Merci d'utiliser [la bibliothèque `prop-types` à la place](https://www.npmjs.com/package/prop-types).
 >
->We provide [a codemod script](/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes) to automate the conversion.
+>Nous fournissons [un scripte codemod](/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes) pour automatiser la conversion.
 
-In a future major release of React, the code that implements PropType validation functions will be stripped in production. Once this happens, any code that calls these functions manually (that isn't stripped in production) will throw an error.
+Dans une future version majeure de React, le code implémentant les fonctions de validation PropType sera supprimé en production. Une fois que cela se produit, tout code appelant ces fonctions manuellement (qui n'est pas supprimé en production) génèrera une erreur.
 
-### Declaring PropTypes is still fine {#declaring-proptypes-is-still-fine}
+### Déclarer des PropTypes est toujours correct {#declaring-proptypes-is-still-fine}
 
-The normal usage of PropTypes is still supported:
+L'utilisation normale de PropTypes est toujours prise en charge :
 
 ```javascript
 Button.propTypes = {
@@ -22,11 +22,11 @@ Button.propTypes = {
 };
 ```
 
-Nothing changes here.
+Rien ne channge ici.
 
-### Don’t call PropTypes directly {#dont-call-proptypes-directly}
+### N'appelez pas PropTypes directement {#dont-call-proptypes-directly}
 
-Using PropTypes in any other way than annotating React components with them is no longer supported:
+L'utilisation de PropTypes autrement que par l'annotation de composants React avec eux n'est plus soutenu :
 
 ```javascript
 var apiShape = PropTypes.shape({
@@ -34,17 +34,17 @@ var apiShape = PropTypes.shape({
   statusCode: PropTypes.number.isRequired
 }).isRequired;
 
-// Not supported!
+// N'est plus soutenu !
 var error = apiShape(json, 'response');
 ```
 
-If you depend on using PropTypes like this, we encourage you to use or create a fork of PropTypes (such as [these](https://github.com/aackerman/PropTypes) [two](https://github.com/developit/proptypes) packages).
+Si vous comptez utiliser de tels PropTypes, nous vous encourageons à utiliser ou créer un fork de PropTypes (tels que [ces](https://github.com/aackerman/PropTypes) [deux](https://github.com/developit/proptypes) paquets).
 
-If you don't fix the warning, this code will crash in production with React 16.
+Si vous ne corrigez pas l'avertissement, ce code plantera en production avec React 16.
 
-### If you don't call PropTypes directly but still get the warning {#if-you-dont-call-proptypes-directly-but-still-get-the-warning}
+### Si vous n'appelez pas directement PropTypes mais recevez toujours l'avertissement {#if-you-dont-call-proptypes-directly-but-still-get-the-warning}
 
-Inspect the stack trace produced by the warning. You will find the component definition responsible for the PropTypes direct call. Most likely, the issue is due to third-party PropTypes that wrap React’s PropTypes, for example:
+Inspectez la trace de pile générée par l'avertissement. Vous trouverez la définition de composant responsable de l'appel direct PropTypes. Le problème est probablement dû à des PropTypes tiers qui enveloppent les PropTypes de React, par exemple :
 
 ```js
 Button.propTypes = {
@@ -55,13 +55,13 @@ Button.propTypes = {
 }
 ```
 
-In this case, `ThirdPartyPropTypes.deprecated` is a wrapper calling `PropTypes.bool`. This pattern by itself is fine, but triggers a false positive because React thinks you are calling PropTypes directly. The next section explains how to fix this problem for a library implementing something like `ThirdPartyPropTypes`. If it's not a library you wrote, you can file an issue against it.
+Dans ce cas, `ThirdPartyPropTypes.deprecated` est un container appelant` PropTypes.bool`. Ce modèle en soi est correct, mais déclenche un faux positif car React pense que vous appelez directement PropTypes. La section suivante explique comment résoudre ce problème pour une bibliothèque implémentant quelque chose similaire à `ThirdPartyPropTypes`. Si ce n'est pas une bibliothèque que vous avez écrite, vous pouvez créer un problème à ce sujet.
 
-### Fixing the false positive in third party PropTypes {#fixing-the-false-positive-in-third-party-proptypes}
+### Correction du faux positif dans les PropTypes tiers {#fixing-the-false-positive-in-third-party-proptypes}
 
-If you are an author of a third party PropTypes library and you let consumers wrap existing React PropTypes, they might start seeing this warning coming from your library. This happens because React doesn't see a "secret" last argument that [it passes](https://github.com/facebook/react/pull/7132) to detect manual PropTypes calls.
+Si vous êtes l'auteur d'une bibliothèque PropTypes tierce et que vous laissez les consommateurs encapsuler les PropTypes React existants, ils peuvent commencer à voir cet avertissement provenant de votre bibliothèque. Cela est dû au fait que React ne voit pas le dernier argument "secret" qu'il [passe](https://github.com/facebook/react/pull/7132) pour détecter les appels manuels PropTypes.
 
-Here is how to fix it. We will use `deprecated` from [react-bootstrap/react-prop-types](https://github.com/react-bootstrap/react-prop-types/blob/0d1cd3a49a93e513325e3258b28a82ce7d38e690/src/deprecated.js) as an example. The current implementation only passes down the `props`, `propName`, and `componentName` arguments:
+Voici comment y remédier. Nous utiliserons `deprecated` à partir de  [react-bootstrap/react-prop-types](https://github.com/react-bootstrap/react-prop-types/blob/0d1cd3a49a93e513325e3258b28a82ce7d38e690/src/deprecated.js) comme exemple. L'implémentation actuelle ne transmet que les arguments `props`, `propName`, et `componentName` :
 
 ```javascript
 export default function deprecated(propType, explanation) {
@@ -79,7 +79,7 @@ export default function deprecated(propType, explanation) {
 }
 ```
 
-In order to fix the false positive, make sure you pass **all** arguments down to the wrapped PropType. This is easy to do with the ES6 `...rest` notation:
+Afin de corriger le faux positif, assurez-vous de transmettre **tous** les arguments au PropType encapsulé. Chose facile à faire avec la notation ES6 `... rest`:
 
 ```javascript
 export default function deprecated(propType, explanation) {
@@ -97,4 +97,4 @@ export default function deprecated(propType, explanation) {
 }
 ```
 
-This will silence the warning.
+Cela fera taire l'avertissement.

--- a/content/warnings/dont-call-proptypes.md
+++ b/content/warnings/dont-call-proptypes.md
@@ -59,7 +59,7 @@ Button.propTypes = {
 
 Dans ce cas, `ThirdPartyPropTypes.deprecated` est un enrobage qui appelle `PropTypes.bool`. Ce modèle n’a rien de mauvais en soi, mais il déclenche un faux positif car React pense que vous appelez directement PropTypes. La section suivante explique comment résoudre ce problème pour une bibliothèque implémentant quelque chose de similaire à `ThirdPartyPropTypes`. Si ce n'est pas une bibliothèque que vous avez écrite, vous pouvez déposer une *issue* sur son dépôt public.
 
-### Correction du faux positif dans les PropTypes tiers {#fixing-the-false-positive-in-third-party-proptypes}
+### Corriger le faux positif des PropTypes tiers {#fixing-the-false-positive-in-third-party-proptypes}
 
 Si vous êtes l'auteur·e d'une bibliothèque PropTypes tierce et que vous laissez vos utilisateurs enrober les PropTypes React existants, ils risquent de voir apparaître cet avertissement provenant de votre bibliothèque. C’est dû au fait que React ne voit pas le dernier argument « secret » qu'il [passe](https://github.com/facebook/react/pull/7132) pour détecter les appels manuels à PropTypes.
 

--- a/content/warnings/dont-call-proptypes.md
+++ b/content/warnings/dont-call-proptypes.md
@@ -8,7 +8,7 @@ N’appelez pas les PropTypes
 
 > Remarque
 >
-> `React.PropTypes` a été déplacé dans un paquet différent depuis React v15.5. Merci d'utiliser [la bibliothèque `prop-types` à la place](https://www.npmjs.com/package/prop-types).
+> `React.PropTypes` a été déplacé dans un paquet dédié depuis React v15.5. Merci d'utiliser désormais [la bibliothèque `prop-types`](https://www.npmjs.com/package/prop-types).
 >
 >Nous fournissons [un script codemod](/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes) pour automatiser la conversion.
 

--- a/content/warnings/dont-call-proptypes.md
+++ b/content/warnings/dont-call-proptypes.md
@@ -61,7 +61,7 @@ Dans ce cas, `ThirdPartyPropTypes.deprecated` est un container appelant `PropTyp
 
 ### Correction du faux positif dans les PropTypes tiers {#fixing-the-false-positive-in-third-party-proptypes}
 
-Si vous êtes l'auteur d'une bibliothèque PropTypes tierce et que vous laissez les consommateurs encapsuler les PropTypes React existants, ils peuvent commencer à voir cet avertissement provenant de votre bibliothèque. Cela est dû au fait que React ne voit pas le dernier argument "secret" qu'il [passe](https://github.com/facebook/react/pull/7132) pour détecter les appels manuels PropTypes.
+Si vous êtes l'auteur·e d'une bibliothèque PropTypes tierce et que vous laissez vos utilisateurs enrober les PropTypes React existants, ils risquent de voir apparaître cet avertissement provenant de votre bibliothèque. C’est dû au fait que React ne voit pas le dernier argument « secret » qu'il [passe](https://github.com/facebook/react/pull/7132) pour détecter les appels manuels à PropTypes.
 
 Voici comment y remédier. Nous utiliserons `deprecated` à partir de  [react-bootstrap/react-prop-types](https://github.com/react-bootstrap/react-prop-types/blob/0d1cd3a49a93e513325e3258b28a82ce7d38e690/src/deprecated.js) comme exemple. L'implémentation actuelle ne transmet que les arguments `props`, `propName`, et `componentName` :
 


### PR DESCRIPTION
Hésitation pour `crash` entre `planter` et `échouer`.

Je n'ai pas traduit les messages d'avertissement à l'intérieur des déclarations PropTypes.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
