### PR TITLE
Translate Community/Tools/Debugging page

### DIFF
--- a/content/community/tools-debugging.md
+++ b/content/community/tools-debugging.md
@@ -1,8 +1,8 @@
 ---
 id: debugging-tools
-title: Debugging
+title: Débogage
 layout: community
 permalink: community/debugging-tools.html
 ---
 
-  * **[React Developer Tools](https://github.com/facebook/react-devtools):** an extension available for [Chrome](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi), [Firefox](https://addons.mozilla.org/firefox/addon/react-devtools/), and as a [standalone app](https://github.com/facebook/react-devtools/tree/master/packages/react-devtools) that allows you to inspect the React component hierarchy in the Chrome Developer Tools.
+  * **[React Developer Tools](https://github.com/facebook/react-devtools) :** une extension disponible pour [Chrome](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi?hl=fr), [Firefox](https://addons.mozilla.org/firefox/addon/react-devtools/), et sous forme [d'application autonome](https://github.com/facebook/react-devtools/tree/master/packages/react-devtools) vous permettant d'inspecter la hiérarchie des composants React dans les outils de développement du navigateur.


### PR DESCRIPTION
Hello,

Voici ma traduction de la page https://reactjs.org/community/debugging-tools.html

J'ai changé la traduction de `(...) in the Chrome Developer Tools.` parce que ça me fait bizarre de parler de "Chrome Dev Tools" dans Firefox 😉 