### PR TITLE
Update react-without-jsx.md

### DIFF
--- a/content/docs/react-without-jsx.md
+++ b/content/docs/react-without-jsx.md
@@ -26,14 +26,16 @@ ReactDOM.render(
 Il peut être compilé vers ce code qui n'utilise pas JSX :
 
 ```js
-class Hello extends React.Component {
+import {Component, createElement} from "react";
+
+class Hello extends Component {
   render() {
-    return React.createElement('div', null, `Bonjour ${this.props.toWhat}`);
+    return createElement('div', null, `Bonjour ${this.props.toWhat}`);
   }
 }
 
 ReactDOM.render(
-  React.createElement(Hello, {toWhat: 'monde'}, null),
+  createElement(Hello, {toWhat: 'monde'}, null),
   document.getElementById('root')
 );
 ```
@@ -42,16 +44,16 @@ Si vous voulez voir plus d'exemples de conversion de code JSX en JavaScript brut
 
 Le composant peut être soit une chaîne de caractères, soit une sous-classe de `React.Component`, soit une fonction simple pour les composants sans état.
 
-Si vous n'avez pas envie de taper `React.createElement` à chaque fois, vous pouvez à la place créer un raccourci :
+Si vous n'avez pas envie de taper `createElement` à chaque fois, vous pouvez à la place créer un raccourci :
 
 ```js
-const e = React.createElement;
+import {createElement as e} from "react";
 
 ReactDOM.render(
   e('div', null, 'Bonjour, monde'),
   document.getElementById('root')
 );
 ```
-Si vous utilisez un tel raccourci pour `React.createElement`, utiliser React sans JSX devient presque aussi pratique.
+Si vous utilisez un tel raccourci pour `createElement`, utiliser React sans JSX devient presque aussi pratique.
 
 Dans le même esprit, vous pouvez aller regarder des projets tels que [`react-hyperscript`](https://github.com/mlmorg/react-hyperscript) ou [`hyperscript-helpers`](https://github.com/ohanhi/hyperscript-helpers), qui proposent une syntaxe encore plus concise.


### PR DESCRIPTION
I think that importing React entirely and then explaining to the users that it is impractical to call React.createElement is misleading. Why not just import the needed modules instead?



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
