### PR TITLE
oubli du verbe être

### DIFF
--- a/content/docs/refs-and-the-dom.md
+++ b/content/docs/refs-and-the-dom.md
@@ -37,7 +37,7 @@ Vous serez peut-être enclin·e à toujours commencer par une ref pour « faire
 
 ### Créer des refs {#creating-refs}
 
-Les refs sont créées en utilisant `React.createRef()` et attachées aux éléments React via l'attribut `ref`. Les refs sont souvent affectées à une propriété d'instance quand un composant est construit et peuvent donc référencées à travers le composant.
+Les refs sont créées en utilisant `React.createRef()` et attachées aux éléments React via l'attribut `ref`. Les refs sont souvent affectées à une propriété d'instance quand un composant est construit et peuvent donc être référencées à travers le composant.
 
 ```javascript{4,7}
 class MyComponent extends React.Component {


### PR DESCRIPTION
Pas certain que se soit les refs qui doivent être référencées mais sans le verbe "être" il y a un problème de sens.


<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
