### PR TITLE
Traduction de la page Canaux de sortie

### DIFF
--- a/content/docs/nav.yml
+++ b/content/docs/nav.yml
@@ -62,7 +62,7 @@
     - id: portals
       title: Portails
     - id: profiler
-      title: Profiler
+      title: Profileur
     - id: react-without-es6
       title: React sans ES6
     - id: react-without-jsx

--- a/content/docs/reference-profiler.md
+++ b/content/docs/reference-profiler.md
@@ -1,27 +1,25 @@
 ---
 id: profiler
-title: Profiler API
+title: API du profileur
 layout: docs
 category: Reference
 permalink: docs/profiler.html
 ---
 
-The `Profiler` measures how often a React application renders and what the "cost" of rendering is.
-Its purpose is to help identify parts of an application that are slow and may benefit from [optimizations such as memoization](https://reactjs.org/docs/hooks-faq.html#how-to-memoize-calculations).
+Le `Profiler` mesure à quelle fréquence une application React réalise son rendu, et détermine le « coût » de ces rendus.  L’objectif est de vous aider à identifier les parties d’une application qui sont lentes et pourraient bénéficier [d’optimisations telles que la mémoïsation](https://reactjs.org/docs/hooks-faq.html#how-to-memoize-calculations).
 
-> Note:
+> Remarque
 >
-> Profiling adds some additional overhead, so **it is disabled in [the production build](https://reactjs.org/docs/optimizing-performance.html#use-the-production-build)**.
+> Le profilage pénalise légèrement les performances effectives, il est donc **désactivé dans [le build de production](https://reactjs.org/docs/optimizing-performance.html#use-the-production-build)**.
 >
-> To opt into production profiling, React provides a special production build with profiling enabled.
-> Read more about how to use this build at [fb.me/react-profiling](https://fb.me/react-profiling)
+> Pour activer le profilage en production, React fournit un build de production spécifique avec le profilage
+> activé.  Vous pouvez apprendre comment l’utiliser sur [fb.me/react-profiling](https://fb.me/react-profiling).
 
-## Usage {#usage}
+## Utilisation {#usage}
 
-A `Profiler` can be added anywhere in a React tree to measure the cost of rendering that part of the tree.
-It requires two props: an `id` (string) and an `onRender` callback (function) which React calls any time a component within the tree "commits" an update.
+Un `Profiler` peut être ajouté n’importe où dans l’arborescence React pour mesurer le coût de rendu de la partie de l’arbre qu’il entoure.  Il nécessite deux props : un `id` (chaîne de caractères) et une fonction de rappel `onRender` que React appellera dès qu’un composant au sein de l’arborescence enrobée « finalise » *(“commits”, NdT)* une mise à jour.
 
-For example, to profile a `Navigation` component and its descendants:
+Par exemple, pour profiler le composant `Navigation` et ses descendants, on ferait ceci :
 
 ```js{3}
 render(
@@ -34,7 +32,8 @@ render(
 );
 ```
 
-Multiple `Profiler` components can be used to measure different parts of an application:
+Vous pouvez utiliser plusieurs composants `Profiler` pour mesurer différentes parties d’une même application :
+
 ```js{3,6}
 render(
   <App>
@@ -48,7 +47,8 @@ render(
 );
 ```
 
-`Profiler` components can also be nested to measure different components within the same subtree:
+Les composants `Profiler` peuvent par ailleurs être imbriqués pour mesurer différents périmètres dans une même partie de l’arborescence :
+
 ```js{2,6,8}
 render(
   <App>
@@ -66,54 +66,52 @@ render(
 );
 ```
 
-> Note
+> Remarque
 >
-> Although `Profiler` is a light-weight component, it should be used only when necessary; each use adds some CPU and memory overhead to an application.
+> Même si `Profiler` est un composant léger, il ne devrait être utilisé que lorsqu’il est nécessaire, car chaque utilisation entraîne une pénalité en termes de processeur et de mémoire pour l’application.
 
-## `onRender` Callback {#onrender-callback}
+## Fonction de rappel `onRender` {#onrender-callback}
 
-The `Profiler` requires an `onRender` function as a prop.
-React calls this function any time a component within the profiled tree "commits" an update.
-It receives parameters describing what was rendered and how long it took.
+Le `Profiler` nécessite une fonction `onRender` dans ses props.  React appelle cette fonction dès qu’un composant dans l’arbre profilé « finalise » *(“commits”, NdT)* une mise à jour.  La fonction reçoit des paramètres dérivant ce qui vient de faire l‘objet d’un rendu, et le temps que ça a pris.
 
 ```js
 function onRenderCallback(
-  id, // the "id" prop of the Profiler tree that has just committed
-  phase, // either "mount" (if the tree just mounted) or "update" (if it re-rendered)
-  actualDuration, // time spent rendering the committed update
-  baseDuration, // estimated time to render the entire subtree without memoization
-  startTime, // when React began rendering this update
-  commitTime, // when React committed this update
-  interactions // the Set of interactions belonging to this update
+  id, // la prop "id" du Profiler dont l’arborescence vient d’être mise à jour
+  phase, // soit "mount" (si on est au montage) soit "update" (pour une mise à jour)
+  actualDuration, // temps passé à faire le rendu de la mise à jour finalisée
+  baseDuration, // temps estimé du rendu pour l’ensemble du sous-arbre sans mémoïsation
+  startTime, // horodatage du début de rendu de cette mise à jour par React
+  commitTime, // horodatage de la finalisation de cette mise à jour par React
+  interactions // Un Set des interactions qui constituent cette mise à jour
 ) {
-  // Aggregate or log render timings...
+  // Agrège ou logue les mesures de rendu…
 }
 ```
 
-Let's take a closer look at each of the props:
+Examinons chaque argument d’un peu plus près…
 
-* **`id: string`** - 
-The `id` prop of the `Profiler` tree that has just committed.
-This can be used to identify which part of the tree was committed if you are using multiple profilers.
+* **`id: string`** -
+la prop `id` du `Profiler` dont l’arbre vient d’être finalisé.
+On s’en sert pour identifier la partie de l’arbre qui vient d’être finalisée si on utilise plusieurs profileurs.
 * **`phase: "mount" | "update"`** -
-Identifies whether the tree has just been mounted for the first time or re-rendered due to a change in props, state, or hooks.
+nous permet de savoir si l’arbre vient d’être monté (premier rendu) ou si c’est un nouveau rendu suite à une modification des props, de l’état local ou de hooks.
 * **`actualDuration: number`** -
-Time spent rendering the `Profiler` and its descendants for the current update.
-This indicates how well the subtree makes use of memoization (e.g. [`React.memo`](/docs/react-api.html#reactmemo), [`useMemo`](/docs/hooks-reference.html#usememo), [`shouldComponentUpdate`](/docs/hooks-faq.html#how-do-i-implement-shouldcomponentupdate)).
-Ideally this value should decrease significantly after the initial mount as many of the descendants will only need to re-render if their specific props change.
+temps passé à faire le rendu du `Profiler` et de ses descendants lors de la mise à jour courante.
+Nous permet de voir dans quelle mesure le sous-arbre tire parti de la mémoïsation (ex. [`React.memo`](/docs/react-api.html#reactmemo), [`useMemo`](/docs/hooks-reference.html#usememo), [`shouldComponentUpdate`](/docs/hooks-faq.html#how-do-i-implement-shouldcomponentupdate)).
+Dans l’idéal cette valeur devrait décroître significativement après le montage initial, car de nombreux descendants ne devraient nécessiter un nouveau rendu que si leurs propres props changent.
 * **`baseDuration: number`** -
-Duration of the most recent `render` time for each individual component within the `Profiler` tree.
-This value estimates a worst-case cost of rendering (e.g. the initial mount or a tree with no memoization).
+durée du `render` le plus récent qui revisitait l’ensemble des composants dans l’arbre enrobé par le `Profiler`.
+Cette valeur nous permet d’estimer un scénario du pire (ex. le montage initial ou un arbre sans mémoïsation).
 * **`startTime: number`** -
-Timestamp when React began rendering the current update.
+horodatage du début du rendu de la mise à jour courante par React.
 * **`commitTime: number`** -
-Timestamp when React committed the current update.
-This value is shared between all profilers in a commit, enabling them to be grouped if desirable.
+horodatage de la finalisation de la mise à jour courante par React.
+Cette valeur est partagée entre tous les profileurs d’une même finalisation, ce qui permet de les regrouper si on le souhaite.
 * **`interactions: Set`** -
-Set of ["interactions"](http://fb.me/react-interaction-tracing) that were being traced the update was scheduled (e.g. when `render` or `setState` were called).
+un `Set` des [« interactions »](http://fb.me/react-interaction-tracing) qui ont été pistées lors de la planification de la mise à jour (ex. lors des appels à `render` ou `setState`).
 
-> Note
+> Remarque
 >
-> Interactions can be used to identify the cause of an update, although the API for tracing them is still experimental.
+> Vous pouvez utiliser les interactions pour identifier la cause d’une mise à jour, même si l’API pour le pistage des interactions est encore expérimentale.
 >
-> Learn more about it at [fb.me/react-interaction-tracing](http://fb.me/react-interaction-tracing)
+> Vous pouvez en apprendre davantage sur [fb.me/react-interaction-tracing](http://fb.me/react-interaction-tracing).

--- a/content/docs/release-channels.md
+++ b/content/docs/release-channels.md
@@ -1,95 +1,96 @@
 ---
 id: release-channels
-title: Release Channels
+title: Canaux de sortie
 permalink: docs/release-channels.html
 layout: docs
 category: installation
 ---
 
-React relies on a thriving open source community to file bug reports, open pull requests, and [submit RFCs](https://github.com/reactjs/rfcs). To encourage feedback we sometimes share special builds of React that include unreleased features.
+React dépend d’une communauté open source florissante pour signaler des bugs, ouvrir des *pull requests* et [soumettre des RFC](https://github.com/reactjs/rfcs). Afin d’encourager des retours efficaces nous partageons parfois des builds spéciaux de React qui comportent des fonctionnalités encore officieuses.
 
-> This document will be most relevant to developers who work on frameworks, libraries, or developer tooling. Developers who use React primarily to build user-facing applications should not need to worry about our prerelease channels.
+> Ce document sera surtout pertinent pour les développeur·se·s qui travaillent sur des frameworks, des bibliothèques ou de l’outillage de développement.  Les personnes qui utilisent React principalement pour construire des applications destinées à des utilisateurs finaux ne devraient pas avoir à se préoccuper de nos canaux de sortie.
 
-Each of React's release channels is designed for a distinct use case:
+Chaque canal de sortie React est conçu pour des cas d’usages bien spécifiques :
 
-- [**Latest**](#latest-channel) is for stable, semver React releases. It's what you get when you install React from npm. This is the channel you're already using today. **Use this for all user-facing React applications.**
-- [**Next**](#next-channel) tracks the master branch of the React source code repository. Think of these as release candidates for the next minor semver release. Use this for integration testing between React and third party projects.
-- [**Experimental**](#experimental-channel) includes experimental APIs and features that aren't available in the stable releases. These also track the master branch, but with additional feature flags turned on. Use this to try out upcoming features before they are released.
+- [**Latest**](#latest-channel) fournit les versions stables de React, conformes à semver.  C’est ce que vous obtenez en installant React depuis npm.  C’est le canal que vous utilisez déjà aujourd’hui. **Utilisez ce canal pour toute application React visant des utilisateurs finaux.**
+- [**Next**](#next-channel) est basée sur la branche `master` du dépôt de code source de React.  Considérez-le comme des versions candidates de la prochaine version semver mineure.  Utilisez-le pour faire des tests d’intégration entre React et des projets tiers.
+- [**Experimental**](#experimental-channel) comprend les API et fonctionnalités expérimentales qu’on ne trouve pas dans les versions stables.  C’est là aussi basé sur la branche `master`, mais des drapeaux de fonctionnalités supplémentaires ont été activés.  Utilisez ce canal pour essayer des fonctionnalités à venir en amont de leur sortie officielle.
 
-All releases are published to npm, but only Latest uses [semantic versioning](/docs/faq-versioning.html). Prereleases (those in the Next and Experimental channels) have versions generated from a hash of their contents, e.g. `0.0.0-1022ee0ec` for Next and `0.0.0-experimental-1022ee0ec` for Experimental.
+Toutes ces versions sont publiées sur npm, mais seul *Latest* utilise [une gestion sémantique des versions](/docs/faq-versioning.html). Les pré-versions (celles des canaux *Next* et *Experimental*) ont des versions dont l’identifiant est un hash basé sur leur contenu, par exemple `0.0.0-1022ee0ec` pour *Next* et `0.0.0-experimental-1022ee0ec` pour *Experimental*.
 
-**The only officially supported release channel for user-facing applications is Latest**. Next and Experimental releases are provided for testing purposes only, and we provide no guarantees that behavior won't change between releases. They do not follow the semver protocol that we use for releases from Latest.
+**Latest est le seul canal de sortie officiellement autorisé pour des applications visant les utilisateurs finaux.**  Les sorties des canaux *Next* et *Experimental* sont fournies dans une optique de tests uniquement, et leur comportement est susceptible de varier d’une sortie à l’autre.  Elles ne respectent pas le protocole semver que nous utilisons pour les sorties du canal *Latest*.
 
-By publishing prereleases to the same registry that we use for stable releases, we are able to take advantage of the many tools that support the npm workflow, like [unpkg](https://unpkg.com) and [CodeSandbox](https://codesandbox.io).
+En publiant les pré-versions sur le même référentiel que pour les versions stables, nous pouvons tirer parti des nombreux outils qui se basent sur npm pour fonctionner, tels que [unpkg](https://unpkg.com) et [CodeSandbox](https://codesandbox.io).
 
-### Latest Channel
+### Canal *Latest*
 
-Latest is the channel used for stable React releases. It corresponds to the `latest` tag on npm. It is the recommended channel for all React apps that are shipped to real users.
+Le canal *Latest* est utilisé pour les versions stables de React.  Il correspond à l’étiquette `latest` sur npm.  C’est le canal recommandé pour toute appli React proposée à de véritables utilisateurs.
 
-**If you're not sure which channel you should use, it's Latest.** If you're a React developer, this is what you're already using.
+**Si vous n’êtes pas sûr·e du canal que vous devriez utiliser, alors c’est *Latest*.**  Si vous développez avec React, c’est ce que vous utilisez déjà.
 
-You can expect updates to Latest to be extremely stable. Versions follow the semantic versioning scheme. Learn more about our commitment to stability and incremental migration in our [versioning policy](/docs/faq-versioning.html).
+Vous pouvez vous attendre à ce que les mises à jour sur *Latest* soient extrêmement stables.  On y suit un protocole sémantique de gestion des versions.  Vous pouvez en apprendre davantage sur nos engagements en termes de stabilité et de migration incrémentielle en consultant notre [politique de gestion des versions](/docs/faq-versioning.html).
 
-### Next Channel
+### Canal *Next*
 
-The Next channel is a prerelease channel that tracks the master branch of the React repository. We use prereleases in the Next channel as release candidates for the Latest channel. You can think of Next as a superset of Latest that is updated more frequently.
+Le canal *Next* est un canal de pré-version qui piste la branche `master` du dépôt React.  Nous utilisons les pré-versions du canal *Next* comme des versions candidates pour le canal *Latest*.  Vous pouvez imaginer *Next* comme un sur-ensemble de *Latest*, mis à jour plus fréquemment.
 
-The degree of change between the most recent Next release and the most recent Latest release is approximately the same as you would find between two minor semver releases. However, **the Next channel does not conform to semantic versioning.** You should expect occasional breaking changes between successive releases in the Next channel.
+L’ampleur des changements entre la version *Next* la plus récente et la dernière version *Latest* est à peu près du même ordre que ce que vous trouveriez entre deux versions semver mineures.  En revanche, **le canal *Next* ne respecte pas la gestion sémantique des versions.**  Vous êtes susceptible d’y rencontrer des ruptures de compatibilité ascendante d’une version à la suivante.
 
-**Do not use prereleases in user-facing applications.**
+**N’utilisez pas les pré-versions dans des applications pour utilisateurs finaux.**
 
-Releases in Next are published with the `next` tag on npm. Versions are generated from a hash of the build's contents, e.g. `0.0.0-1022ee0ec`.
+Les sorties de *Next* sont publiées avec l’étiquette `next` sur npm.  Les numéros de versions sont générés sur la base d’un hash de leur contenu, par exemple `0.0.0-1022ee0ec`.
 
-#### Using the Next Channel for Integration Testing
+#### Utiliser le canal *Next* pour des tests d’intégration
 
-The Next channel is designed to support integration testing between React and other projects.
+Le canal *Next* est conçu pour permettre des tests d’intégration entre React et d’autres projets qui se basent dessus.
 
-All changes to React go through extensive internal testing before they are released to the public. However, there are a myriad of environments and configurations used throughout the React ecosystem, and it's not possible for us to test against every single one.
+Toutes les modifications apportées à React passent par une phase poussée de tests internes avant d’être publiées.  Cependant, l’écosystème React recèle une myriade d’environnements et de configurations, et il nous est parfaitement impossible de tester chaque combinaison.
 
-If you're the author of a third party React framework, library, developer tool, or similar infrastructure-type project, you can help us keep React stable for your users and the entire React community by periodically running your test suite against the most recent changes. If you're interested, follow these steps:
+Si vous êtes l’auteur·e d’une solution tierce pour React (framework, bibliothèque, outil de développement ou d’autres projets de type infrastructurel), vous pouvez nous aider à préserver la stabilité de React pour vos utilisateurs et la communauté React toute entière en exécutant régulièrement votre suite de tests avec les dernières modifications en date.  Si cela vous intéresse, suivez ces étapes :
 
-- Set up a cron job using your preferred continuous integration platform. Cron jobs are supported by both [CircleCI](https://circleci.com/docs/2.0/triggers/#scheduled-builds) and [Travis CI](https://docs.travis-ci.com/user/cron-jobs/).
-- In the cron job, update your React packages to the most recent React release in the Next channel, using `next` tag on npm. Using the npm cli:
+- Mettez en place une tâche périodique au sein de votre plate-forme préférée d’intégration continue.  On trouve ce type d’exécutions périodiques tant dans [CircleCI](https://circleci.com/docs/2.0/triggers/#scheduled-builds) que dans [Travis CI](https://docs.travis-ci.com/user/cron-jobs/).
+- Dans la tâche, mettez à jour les modules React à partir de la version la plus récente du canal *Next*, grâce à l’étiquette `next` sur npm.  Avec la CLI de npm :
 
   ```
   npm update react@next react-dom@next
   ```
 
-  Or yarn:
+  Ou avec Yarn :
 
   ```
   yarn upgrade react@next react-dom@next
   ```
-- Run your test suite against the updated packages.
-- If everything passes, great! You can expect that your project will work with the next minor React release.
-- If something breaks unexpectedly, please let us know by [filing an issue](https://github.com/facebook/react/issues).
 
-A project that uses this workflow is Next.js. (No pun intended! Seriously!) You can refer to their [CircleCI configuration](https://github.com/zeit/next.js/blob/c0a1c0f93966fe33edd93fb53e5fafb0dcd80a9e/.circleci/config.yml) as an example.
+- Exécutez votre suite de tests avec les modules ainsi mis à jour.
+- Si tout fonctione, super !  Vous pouvez vous attendre à ce que votre projet continue à fonctionner avec la prochaine version mineure de React.
+- Si quelque chose casse de façon inattendue, merci de nous le signaler en [créant un ticket](https://github.com/facebook/react/issues).
 
-### Experimental Channel
+Le projet Next.js (promis, on n’a pas fait exprès !) utilise cette approche.  Vous pouvez consulter leur [configuration CircleCI](https://github.com/zeit/next.js/blob/c0a1c0f93966fe33edd93fb53e5fafb0dcd80a9e/.circleci/config.yml) à titre d’exemple.
 
-Like Next, the Experimental channel is a prerelease channel that tracks the master branch of the React repository. Unlike Next, Experimental releases include additional features and APIs that are not ready for wider release.
+### Canal *Experimental*
 
-Usually, an update to Next is accompanied by a corresponding update to Experimental. They are based on the same source revision, but are built using a different set of feature flags.
+Tout comme *Next*, le canal *Experimental* est un canal de pré-versions qui piste la branche `master` du dépôt React.  Mais contrairement à *Next*, les sorties sur *Experimental* comportent des fonctionnalités et API qui ne sont pas encore prêtes à être diffusées plus largement.
 
-Experimental releases may be significantly different than releases to Next and Latest. **Do not use Experimental releases in user-facing applications.** You should expect frequent breaking changes between releases in the Experimental channel.
+En général, une mise à jour sur *Next* est accompagnée par une mise à jour correspondante sur *Experimental*.  Elles sont basées sur la même révision de source, mais sont construites avec des jeux distincts de drapeaux de fonctionnalités.
 
-Releases in Experimental are published with the `experimental` tag on npm. Versions are generated from a hash of the build's contents, e.g. `0.0.0-experimental-1022ee0ec`.
+Les versions sur *Experimental* peuvent différer considérablement de celles sur *Next* et *Latest*. **N’utilisez pas les pré-versions *Experimental* dans les applications pour utilisateurs finaux.**  Vous pouvez vous attendre à des ruptures fréquentes de compatibilité ascendante dans les sorties du canal *Experimental*.
 
-#### What Goes Into an Experimental Release?
+Les sorties de *Experimental* sont publiées avec l’étiquette `experimental` sur npm.  Les numéros de versions sont générés sur la base d’un hash de leur contenu, par exemple `0.0.0-experimental-1022ee0ec`.
 
-Experimental features are ones that are not ready to be released to the wider public, and may change drastically before they are finalized. Some experiments may never be finalized -- the reason we have experiments is to test the viability of proposed changes.
+#### Que trouve-t-on dans une sortie *Experimental* ?
 
-For example, if the Experimental channel had existed when we announced Hooks, we would have released Hooks to the Experimental channel weeks before they were available in Latest.
+Les fonctionnalités expérimentales ne sont pas encore prêtes à être livrées à un large public, et sont susceptibles de changer radicalement d’ici leur finalisation.  Certaines expériences n’aboutiront peut-être même jamais—c’est justement pour tester la viabilité de changements proposés que nous avons ces expériences.
 
-You may find it valuable to run integration tests against Experimental. This is up to you. However, be advised that Experimental is even less stable than Next. **We do not guarantee any stability between Experimental releases.**
+Par exemple, si le canal *Experimental* avait existé quand nous avons annoncé les Hooks, nous aurions sorti les Hooks sur le canal *Experimental* plusieurs semaines avant qu’ils deviennent disponibles dans *Latest*.
 
-#### How Can I Learn More About Experimental Features?
+Vous trouverez peut-être utile de lancer des tests d‘intégration avec *Experimental*.  Libre à vous.  Ceci dit, gardez bien à l’esprit que *Experimental* est encore moins stable que *Next*. **Nous ne garantissons aucune stabilité d’une version de *Experimental* à une autre.**
 
-Experimental features may or may not be documented. Usually, experiments aren't documented until they are close to shipping in Next or Stable.
+#### Comment en apprendre davantage sur les fonctionnalités expérimentales ?
 
-If a feature is not documented, they may be accompanied by an [RFC](https://github.com/reactjs/rfcs).
+Les fonctionnalités expérimentales ne sont pas nécessairement documentées.  Le plus souvent, les expériences ne sont documentées qu’une fois qu’elles sont sur le point d’être livrées dans *Next* ou *Latest*.
 
-We will post to the [React blog](/blog) when we're ready to announce new experiments, but that doesn't mean we will publicize every experiment.
+Si une fonctionnalité n’est pas documentée, elle peut toutefois être accompagnée d’une [RFC](https://github.com/reactjs/rfcs).
 
-You can always refer to our public GitHub repository's [history](https://github.com/facebook/react/commits/master) for a comprehensive list of changes.
+Lorsque nous sommes prêts à annoncer de nouvelles expériences, nous en parlons sur le [blog React](/blog), mais ça ne veut pas dire que nous annonçons chaque expérience.
+
+Vous pouvez toujours vous référer à l’[historique](https://github.com/facebook/react/commits/master) de notre dépôt public sur GitHub pour une liste exhaustive des modifications.

--- a/content/docs/release-channels.md
+++ b/content/docs/release-channels.md
@@ -14,7 +14,7 @@ Chaque canal de sortie React est conçu pour des cas d’usages bien spécifique
 
 - [**Latest**](#latest-channel) fournit les versions stables de React, conformes à semver.  C’est ce que vous obtenez en installant React depuis npm.  C’est le canal que vous utilisez déjà aujourd’hui. **Utilisez ce canal pour toute application React visant des utilisateurs finaux.**
 - [**Next**](#next-channel) est basée sur la branche `master` du dépôt de code source de React.  Considérez-le comme des versions candidates de la prochaine version semver mineure.  Utilisez-le pour faire des tests d’intégration entre React et des projets tiers.
-- [**Experimental**](#experimental-channel) comprend les API et fonctionnalités expérimentales qu’on ne trouve pas dans les versions stables.  C’est là aussi basé sur la branche `master`, mais des drapeaux de fonctionnalités supplémentaires ont été activés.  Utilisez ce canal pour essayer des fonctionnalités à venir en amont de leur sortie officielle.
+- [**Experimental**](#experimental-channel) comprend les API et fonctionnalités expérimentales qu’on ne trouve pas dans les versions stables. Le canal est également basé sur la branche `master`, mais des drapeaux de fonctionnalités supplémentaires y sont activés.  Utilisez ce canal pour essayer des fonctionnalités à venir en amont de leur sortie officielle.
 
 Toutes ces versions sont publiées sur npm, mais seul *Latest* utilise [une gestion sémantique des versions](/docs/faq-versioning.html). Les pré-versions (celles des canaux *Next* et *Experimental*) ont des versions dont l’identifiant est un hash basé sur leur contenu, par exemple `0.0.0-1022ee0ec` pour *Next* et `0.0.0-experimental-1022ee0ec` pour *Experimental*.
 


### PR DESCRIPTION
Salut @JeremiePat et la team !

Si vous avez un moment sous 24h (je sais, je sais…) j'apprécierais votre relecture de ma trad pour la page sur les Canaux de sortie récemment ajoutée. /ping aux grand·e·s habitué·e·s : @juliettelofaro @lbelavoir @linsolas @forresst @LaureRC…

*D'une façon générale je suis en train de tordre le cou aux quelques pages de doc à proprement parler qui ont fait leur apparition récemment et ne sont pas encore traduites : Tests, Mode Concurrent, le Profiler, les Canaux de Sortie et, pourquoi pas, les trois derniers billets de blog (août et octobre).*