### PR TITLE
Redirect to the fr section of the blog

### DIFF
--- a/content/blog/2018-03-27-update-on-async-rendering.md
+++ b/content/blog/2018-03-27-update-on-async-rendering.md
@@ -32,7 +32,7 @@ cd your_project
 npx react-codemod rename-unsafe-lifecycles
 ```
 
-Vous pouvez en apprendre davantage sur ce codemod dans [le billet d’annonce de la 16.9.0](https://fr.reactjs.org/blog/2019/08/08/react-v16.9.0.html#renaming-unsafe-lifecycle-methods).
+Vous pouvez en apprendre davantage sur ce codemod dans [le billet d’annonce de la 16.9.0](/blog/2019/08/08/react-v16.9.0.html#renaming-unsafe-lifecycle-methods).
 
 ---
 

--- a/content/blog/2018-03-27-update-on-async-rendering.md
+++ b/content/blog/2018-03-27-update-on-async-rendering.md
@@ -32,7 +32,7 @@ cd your_project
 npx react-codemod rename-unsafe-lifecycles
 ```
 
-Vous pouvez en apprendre davantage sur ce codemod dans [le billet d’annonce de la 16.9.0](https://reactjs.org/blog/2019/08/08/react-v16.9.0.html#renaming-unsafe-lifecycle-methods).
+Vous pouvez en apprendre davantage sur ce codemod dans [le billet d’annonce de la 16.9.0](https://fr.reactjs.org/blog/2019/08/08/react-v16.9.0.html#renaming-unsafe-lifecycle-methods).
 
 ---
 


### PR DESCRIPTION

Je suis tombé sur un lien pointant vers la version "en" du blog en quand le "fr" semblait préférable.
Il me semble ne pas avoir vu de PR sur les liens en cours, aussi j’espère que cette première contribution suis bien les bonnes pratiques.