### PR TITLE
Correction de intitulé d'un lien

### DIFF
--- a/content/tutorial/nav.yml
+++ b/content/tutorial/nav.yml
@@ -77,7 +77,7 @@
           href: /tutorial/tutorial.html#taking-turns
           forceInternal: true
         - id: declaring-a-winner
-          title: Déclarer un·e gagnant·e
+          title: Déclarer un vainqueur
           href: /tutorial/tutorial.html#declaring-a-winner
           forceInternal: true
     - id: adding-time-travel


### PR DESCRIPTION
Petite correction pour que l'intitulé du lien corresponde au titre du paragraphe : https://fr.reactjs.org/tutorial/tutorial.html#declaring-a-winner
