### PR TITLE
Correction nom d'une variable

### DIFF
--- a/content/docs/state-and-lifecycle.md
+++ b/content/docs/state-and-lifecycle.md
@@ -244,7 +244,7 @@ La méthode `componentDidMount()` est exécutée après que la sortie du composa
   }
 ```
 
-Notez qu’on a enregistré l'ID du minuteur directement sur `this` (`this.timeID`).
+Notez qu’on a enregistré l'ID du minuteur directement sur `this` (`this.timerID`).
 
 Alors que `this.props` est mis en place par React lui-même et que `this.state` a un sens bien spécial, vous pouvez très bien ajouter manuellement d'autres champs sur la classe si vous avez besoin de stocker quelque chose qui ne participe pas au flux de données (comme un ID de minuteur).
 


### PR DESCRIPTION
Il manque le 'r' dans this.timeID.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
