### PR TITLE
fix: display all react versions in fr.reactjs.org/versions

### DIFF
--- a/content/versions.yml
+++ b/content/versions.yml
@@ -1,3 +1,11 @@
+- title: '17.0.2'
+  changelog: https://github.com/facebook/react/blob/master/CHANGELOG.md#1702-march-22-2021
+- title: '17.0.1'
+  changelog: https://github.com/facebook/react/blob/master/CHANGELOG.md#1701-october-22-2020
+- title: '17.0.0'
+  changelog: https://github.com/facebook/react/blob/master/CHANGELOG.md#1700-october-20-2020
+- title: '16.14.0'
+  changelog: https://github.com/facebook/react/blob/master/CHANGELOG.md#16140-october-14-2020
 - title: '16.13.1'
   changelog: https://github.com/facebook/react/blob/master/CHANGELOG.md#16131-march-19-2020
 - title: '16.13.0'

--- a/src/site-constants.js
+++ b/src/site-constants.js
@@ -8,7 +8,7 @@
 // NOTE: We can't just use `location.toString()` because when we are rendering
 // the SSR part in node.js we won't have a proper location.
 const urlRoot = 'https://fr.reactjs.org';
-const version = '16.13.1';
+const version = '17.0.2';
 const babelURL = 'https://unpkg.com/babel-standalone@6.26.0/babel.min.js';
 
 export {babelURL, urlRoot, version};


### PR DESCRIPTION

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

**What:**
fixes issue [#3663](https://github.com/reactjs/reactjs.org/issues/3663) : 
displays all versions in fr.reactjs.org/versions

Before fix:

![image](https://user-images.githubusercontent.com/24763042/117131482-28790f00-adaa-11eb-90a1-de65beef0a31.png)

After fix:

![image](https://user-images.githubusercontent.com/24763042/117132129-0d5acf00-adab-11eb-8bc8-6366644836a7.png)


**How:** 

- update versions.yml with missing latest versions
- update version const in site-constants.js to latest version 17.0.2


