### PR TITLE
Fix a typo in testing-recipes.md

### DIFF
--- a/content/docs/testing-recipes.md
+++ b/content/docs/testing-recipes.md
@@ -57,7 +57,7 @@ Vous utilisez peut-être une autre approche, mais gardez à l’esprit que vous 
 
 ### `act()` {#act}
 
-Lorsqu’on écrit des tests UI, des tâches comme le rendu lui-même, les événements utilisateurs ou encore le chargement de données peuvent être considérées comme autant « d’unités » d’interaction avec l’interface utilisateur.  `react-dom/rest-utils` fournit une fonction utilitaire appelée [`act()`](/docs/test-utils.html#act) qui s’assure que toutes les mises à jour relatives à ces « unités » ont bien été traitées et appliquées au DOM avant que nous ne commencions à exprimer nos assertions :
+Lorsqu’on écrit des tests UI, des tâches comme le rendu lui-même, les événements utilisateurs ou encore le chargement de données peuvent être considérées comme autant « d’unités » d’interaction avec l’interface utilisateur.  `react-dom/test-utils` fournit une fonction utilitaire appelée [`act()`](/docs/test-utils.html#act) qui s’assure que toutes les mises à jour relatives à ces « unités » ont bien été traitées et appliquées au DOM avant que nous ne commencions à exprimer nos assertions :
 
 ```js
 act(() => {


### PR DESCRIPTION
Fix a typo in `testing-recipes.md`.

A reference to `react-dom/rest-utils` import should be replaced by `react-dom/test-utils`.