### PR TITLE
Fix dead link to openclassrooms React course #3754

### DIFF
--- a/content/community/courses.md
+++ b/content/community/courses.md
@@ -12,7 +12,7 @@ permalink: community/courses.html
 
 ## Cours gratuits {#free-courses}
 
-- [OpenClassrooms : réalisez une application web avec React](https://openclassrooms.com/fr/courses/4664381-realisez-une-application-web-avec-react-js) – Cours détaillé sur l'essentiel de React, y compris comment tester vos composants **(en français)**
+- [OpenClassrooms : débutez avec React](https://openclassrooms.com/fr/courses/7008001-debutez-avec-react) – Cours détaillé sur l'essentiel de React, y compris comment tester vos composants **(en français)**
 
 - [Glitch: React Starter Kit](https://glitch.com/glimmer/post/react-starter-kit) - Cours vidéo gratuit en 5 parties avec des exemples de code interactifs qui vous aideront à apprendre React.
 

--- a/content/community/courses.md
+++ b/content/community/courses.md
@@ -12,7 +12,7 @@ permalink: community/courses.html
 
 ## Cours gratuits {#free-courses}
 
-- [OpenClassrooms : débutez avec React](https://openclassrooms.com/fr/courses/7008001-debutez-avec-react) – Cours détaillé sur l'essentiel de React, y compris comment tester vos composants **(en français)**
+- [OpenClassrooms : débutez avec React](https://openclassrooms.com/fr/courses/7008001-debutez-avec-react) – Cours détaillé sur l'essentiel de React **(en français)**
 
 - [Glitch: React Starter Kit](https://glitch.com/glimmer/post/react-starter-kit) - Cours vidéo gratuit en 5 parties avec des exemples de code interactifs qui vous aideront à apprendre React.
 


### PR DESCRIPTION
As reported [in this issue](https://github.com/reactjs/reactjs.org/issues/3754) from the reactjs.org repo, we had an old deprecated link to Openclassrooms.

This link wasn't dead as described: Openclassrooms redirects to their new course.

Anyway I updated the link.

I also updated the description of the Openclassrooms course : in this new course, there is no component testing as it may have been before.