### PR TITLE
fix(docs): Add missing article "un" in "preserving-and-resetting-state.md"

### DIFF
--- a/src/content/learn/preserving-and-resetting-state.md
+++ b/src/content/learn/preserving-and-resetting-state.md
@@ -735,7 +735,7 @@ export default function MyComponent() {
 </Sandpack>
 
 
-Chaque fois que vous appuyez sur le bouton, l'état du champ de saisie disparaît ! C'est parce qu'une fonction `MyTextField` *différente* est créée à chaque rendu de `MyComponent`. Puisque vous affichez composant *différent* à la même position, React réinitialise tout l'état en dessous. Ça cause des bugs et des problèmes de performances. Pour éviter ce problème, **déclarez toujours les fonctions de composants au niveau racine, et n'imbriquez pas leurs définitions**.
+Chaque fois que vous appuyez sur le bouton, l'état du champ de saisie disparaît ! C'est parce qu'une fonction `MyTextField` *différente* est créée à chaque rendu de `MyComponent`. Puisque vous affichez un composant *différent* à la même position, React réinitialise tout l'état en dessous. Ça cause des bugs et des problèmes de performances. Pour éviter ce problème, **déclarez toujours les fonctions de composants au niveau racine, et n'imbriquez pas leurs définitions**.
 
 </Pitfall>
 


### PR DESCRIPTION
fix(docs): Add missing article "un" in "preserving-and-resetting-state.md"

Corrects the omission of the indefinite article "un" in the "Piège" section in "Des composants différents à la même position"
of the document preserving-and-resetting-state.md.

Document: preserving-and-resetting-state.md
Section: Des composants différents à la même position réinitialisent l’état (Piège)

Before: "Puisque vous affichez composant différent..."
After: "Puisque vous affichez un composant différent..."